### PR TITLE
Documentation typo for default interceptors configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ To disable the default interceptors, pass an empty array, e.g.
 
 ```js
 createPool('postgres://', {
-  interceptos: []
+  interceptors: []
 });
 
 ```


### PR DESCRIPTION
I found Slonik via a friend's tweet. It's a really interesting project, with extremely thorough documentation. Congratulations!

I saw a very minor typo in `README.md` for configuring `interceptors`. This pull request just corrects that.

Cheers!