### PR TITLE
fix: export createTypeParserPreset from root index

### DIFF
--- a/src/factories/index.js
+++ b/src/factories/index.js
@@ -1,5 +1,6 @@
 // @flow
 
 export {default as createInterceptorPreset} from './createInterceptorPreset';
+export {default as createTypeParserPreset} from './createTypeParserPreset';
 export {default as createPool} from './createPool';
 export {default as createPoolTransaction} from './createPoolTransaction';

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export type {
 } from './types';
 export {
   createInterceptorPreset,
+  createTypeParserPreset,
   createPool
 } from './factories';
 export {


### PR DESCRIPTION
This is part of the documentation:

```js
import {
  createTypeParserPreset
} from 'slonik';

createPool('postgres://', {
  typeParsers: [
    ...createTypeParserPreset()
  ]
});
```

But `createTypeParserPreset` is not part of the root `index.js`. This PR adds it to the exports.
