### PR TITLE
Docs: Correct PostgreSQL error names

### DIFF
--- a/.README/ERROR_HANDLING.md
+++ b/.README/ERROR_HANDLING.md
@@ -133,11 +133,11 @@ try {
 
 ### Handling `NotNullIntegrityConstraintViolationError`
 
-`NotNullIntegrityConstraintViolationError` is thrown when PostgreSQL responds with [`unique_violation`](https://www.postgresql.org/docs/9.4/static/errcodes-appendix.html) (`23502`) error.
+`NotNullIntegrityConstraintViolationError` is thrown when PostgreSQL responds with [`not_null_violation`](https://www.postgresql.org/docs/9.4/static/errcodes-appendix.html) (`23502`) error.
 
 ### Handling `ForeignKeyIntegrityConstraintViolationError`
 
-`ForeignKeyIntegrityConstraintViolationError` is thrown when PostgreSQL responds with [`unique_violation`](https://www.postgresql.org/docs/9.4/static/errcodes-appendix.html) (`23503`) error.
+`ForeignKeyIntegrityConstraintViolationError` is thrown when PostgreSQL responds with [`foreign_key_violation`](https://www.postgresql.org/docs/9.4/static/errcodes-appendix.html) (`23503`) error.
 
 ### Handling `UniqueIntegrityConstraintViolationError`
 
@@ -145,4 +145,4 @@ try {
 
 ### Handling `CheckIntegrityConstraintViolationError`
 
-`CheckIntegrityConstraintViolationError` is thrown when PostgreSQL responds with [`unique_violation`](https://www.postgresql.org/docs/9.4/static/errcodes-appendix.html) (`23514`) error.
+`CheckIntegrityConstraintViolationError` is thrown when PostgreSQL responds with [`check_violation`](https://www.postgresql.org/docs/9.4/static/errcodes-appendix.html) (`23514`) error.


### PR DESCRIPTION
I've been hitting some pain points with knex recently, and slonik looks like it will suit my project.

I noticed the integrity constraint error codes were all the same, so here is an updated ERROR_HANDLING.md.

