### PR TITLE
Date parameters

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -299,7 +299,7 @@ export type AssignmentListTokenType = {|
   +type: typeof ComparisonPredicateTokenSymbol
 |};
 
-export type PrimitiveValueExpressionType = string | number | boolean | null;
+export type PrimitiveValueExpressionType = string | number | boolean | Date | null;
 
 export type SqlTokenType =
   ArraySqlTokenType |

--- a/src/utilities/isPrimitiveValueExpression.js
+++ b/src/utilities/isPrimitiveValueExpression.js
@@ -1,5 +1,5 @@
 // @flow
 
 export default (maybe: *): boolean %checks => {
-  return typeof maybe === 'string' || typeof maybe === 'number' || typeof maybe === 'boolean' || maybe === null;
+  return typeof maybe === 'string' || typeof maybe === 'number' || typeof maybe === 'boolean' || maybe instanceof Date || maybe === null;
 };

--- a/test/slonik/templateTags/sql/sql.js
+++ b/test/slonik/templateTags/sql/sql.js
@@ -84,3 +84,16 @@ test('the resulting object is immutable', (t) => {
     query.sql = 'SELECT 2';
   });
 });
+
+test('creates an object describing query value bindings with Date', (t) => {
+  const date = new Date();
+  const query = sql`SELECT ${date}`;
+
+  t.deepEqual(query, {
+    sql: 'SELECT $1',
+    type: SqlTokenSymbol,
+    values: [
+      date
+    ]
+  });
+});

--- a/test/slonik/templateTags/sql/valueList.js
+++ b/test/slonik/templateTags/sql/valueList.js
@@ -56,3 +56,16 @@ test('the resulting object is immutable', (t) => {
     token.foo = 'bar';
   });
 });
+
+test('creates a value list with Date', (t) => {
+  const date = new Date();
+  const query = sql`SELECT (${sql.valueList([date])})`;
+
+  t.deepEqual(query, {
+    sql: 'SELECT ($1)',
+    type: SqlTokenSymbol,
+    values: [
+      date
+    ]
+  });
+});


### PR DESCRIPTION
1. Inconsistent `Date` handling
Added test case showing that `sql` tag throws error if there is `Date` value, while `sql.valueList` doesn't.
```javascript
sql`${new Date()}` // throws
sql`${sql.valueList([new Date()])}` // returns { sql: '$1', type: Symbol(SLONIK_SQL), values: [ <date object> ] }
```

2. Treat `Date` as primitive value
Underlying "node-postgres" library [supports values of type `Date`](https://github.com/brianc/node-postgres/blob/master/lib/utils.js#L60).
Added `Date` to `PrimitiveValueExpressionType` flow type.
Added check to `isPrimitiveValueExpression` function.
