### PR TITLE
fix: allow disabling default typeParsers

### DIFF
--- a/src/factories/createClientConfiguration.js
+++ b/src/factories/createClientConfiguration.js
@@ -2,11 +2,13 @@
 
 import type {
   ClientConfigurationType,
-  ClientUserConfigurationType
+  ClientUserConfigurationType,
+  TypeParserType
 } from '../types';
 import createTypeParserPreset from './createTypeParserPreset';
 
 export default (clientUserConfiguration?: ClientUserConfigurationType): ClientConfigurationType => {
+  const typeParsers: $ReadOnlyArray<TypeParserType> = [];
   const configuration = {
     captureStackTrace: true,
     connectionTimeout: 5000,
@@ -18,12 +20,12 @@ export default (clientUserConfiguration?: ClientUserConfigurationType): ClientCo
     maximumPoolSize: 10,
     minimumPoolSize: 0,
 
-    // $FlowFixMe
-    typeParsers: [],
+    typeParsers,
     ...clientUserConfiguration
   };
 
-  if (!configuration.typeParsers || !configuration.typeParsers.length) {
+  if (!configuration.typeParsers || configuration.typeParsers === typeParsers) {
+    // $FlowFixMe
     configuration.typeParsers = createTypeParserPreset();
   }
 

--- a/test/slonik/factories/createClientConfiguration.js
+++ b/test/slonik/factories/createClientConfiguration.js
@@ -61,3 +61,15 @@ test('overrides provided properties', (t) => {
     }
   );
 });
+
+test('disables default type parsers', (t) => {
+  t.deepEqual(
+    createClientConfiguration({
+      typeParsers: []
+    }),
+    {
+      ...defaultConfiguration,
+      typeParsers: []
+    }
+  );
+});


### PR DESCRIPTION
Fixes #57.

Checks for a specific instance of the empty array in the default config, so that we can appease type-checking (sort of) but still know whether the user passed their own empty array of type parsers.

Still had some odd fight with the typechecker. I've used TypeScript a good bit but never Flow, so I'm not sure if I handled that in the best way.