### PR TITLE
fix: don't quote array type identifiers

### DIFF
--- a/src/sqlFragmentFactories/createArraySqlFragment.js
+++ b/src/sqlFragmentFactories/createArraySqlFragment.js
@@ -4,16 +4,13 @@ import type {
   SqlFragmentType,
   ArraySqlTokenType
 } from '../types';
-import {
-  escapeIdentifier
-} from '../utilities';
 
 export default (token: ArraySqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
   const values = [
     token.values
   ];
 
-  const sql = '$' + (greatestParameterPosition + 1) + '::' + escapeIdentifier(token.memberType) + '[]';
+  const sql = '$' + (greatestParameterPosition + 1) + '::' + token.memberType + '[]';
 
   return {
     sql,

--- a/test/slonik/sqlFragmentFactories/createArraySqlFragment.js
+++ b/test/slonik/sqlFragmentFactories/createArraySqlFragment.js
@@ -13,7 +13,7 @@ test('creates an empty array binding', (t) => {
     values: []
   }, 0);
 
-  t.assert(sqlFragment.sql === '$1::"int4"[]');
+  t.assert(sqlFragment.sql === '$1::int4[]');
   t.deepEqual(sqlFragment.values, [[]]);
 });
 
@@ -26,7 +26,7 @@ test('creates an array binding with a single value', (t) => {
     ]
   }, 0);
 
-  t.assert(sqlFragment.sql === '$1::"int4"[]');
+  t.assert(sqlFragment.sql === '$1::int4[]');
   t.deepEqual(sqlFragment.values, [[1]]);
 });
 
@@ -41,7 +41,7 @@ test('creates an array binding with multiple values', (t) => {
     ]
   }, 0);
 
-  t.assert(sqlFragment.sql === '$1::"int4"[]');
+  t.assert(sqlFragment.sql === '$1::int4[]');
   t.deepEqual(sqlFragment.values, [[1, 2, 3]]);
 });
 
@@ -56,6 +56,6 @@ test('offsets parameter position', (t) => {
     ]
   }, 3);
 
-  t.assert(sqlFragment.sql === '$4::"int4"[]');
+  t.assert(sqlFragment.sql === '$4::int4[]');
   t.deepEqual(sqlFragment.values, [[1, 2, 3]]);
 });

--- a/test/slonik/templateTags/sql/array.js
+++ b/test/slonik/templateTags/sql/array.js
@@ -10,7 +10,7 @@ test('creates a value list', (t) => {
   const query = sql`SELECT ${sql.array([1, 2, 3], 'int4')}`;
 
   t.deepEqual(query, {
-    sql: 'SELECT $1::"int4"[]',
+    sql: 'SELECT $1::int4[]',
     type: SqlTokenSymbol,
     values: [
       [


### PR DESCRIPTION
When used in a SELECT statement, either in WHERE clause or in the columns, the inclusion of double quotes causes PostgreSQL to not be able to parse the type name.

For example, this works:

```
=> select array[1,2,3]::int[];
  array  
---------
 {1,2,3}
(1 row)
```

but this doesn't:

```
=> select array[1,2,3]::"int"[];
ERROR:  type "int[]" does not exist
LINE 1: select array[1,2,3]::"int"[];
```