### PR TITLE
feat: omit undefined values from sql.assignmentList generated sql code

### DIFF
--- a/src/sqlFragmentFactories/createAssignmentListSqlFragment.js
+++ b/src/sqlFragmentFactories/createAssignmentListSqlFragment.js
@@ -20,6 +20,9 @@ export default (token: AssignmentListTokenType, greatestParameterPosition: numbe
 
   const sql = Object
     .entries(token.namedAssignment)
+    .filter(([, value]) => {
+      return value !== undefined;
+    })
     .map(([column, value]) => {
       if (isSqlToken(value)) {
         // $FlowFixMe

--- a/src/types.js
+++ b/src/types.js
@@ -317,8 +317,9 @@ export type ValueExpressionType =
   SqlTokenType |
   PrimitiveValueExpressionType;
 
+export type NamedAssignmentValueType = ValueExpressionType | void;
 export type NamedAssignmentType = {
-  +[key: string]: ValueExpressionType
+  +[key: string]: NamedAssignmentValueType
 };
 
 export type TaggedTemplateLiteralInvocationType = {|

--- a/test/slonik/templateTags/sql/assignmentList.js
+++ b/test/slonik/templateTags/sql/assignmentList.js
@@ -60,6 +60,21 @@ test('converts camel-case to snake-case', (t) => {
   });
 });
 
+test('omits undefined values', (t) => {
+  const query = sql`SELECT ${sql.assignmentList({
+    foo: 'baz',
+    lel: undefined
+  })}`;
+
+  t.deepEqual(query, {
+    sql: 'SELECT "foo" = $1',
+    type: SqlToken,
+    values: [
+      'baz'
+    ]
+  });
+});
+
 test('the resulting object is immutable', (t) => {
   const token = sql.assignmentList({foo: 'bar'});
 


### PR DESCRIPTION
This simplifies cases where you want to pass an object with possible undefined values trough too `sql.assignmentList`, without having to filter out `undefined` values via `delete object.key` or cloning.

## Before:

### With `delete`
```js
const input = {
  foo: "bar",
  lel: undefined
};

if (input.hasOwnProperty("lel") && input.lel === undefined) {
  delete input.lel;
}

sql.assignmentList(input);
```

### Cloning
```js
const input = {
  foo: "bar",
  lel: undefined
};

const sanitizedInput = Object.fromEntries(
  Object.entries(input)
    .filter(([, value]) => value !== undefined)
);

sql.assignmentList(sanitizedInput);
```

## After:

```js
const input = {
  foo: "bar",
  lel: undefined
};

sql.assignmentList(input);
```