### PR TITLE
docs - update default type parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,8 +585,10 @@ These type parsers are enabled by default:
 
 |Type name|Implemnetation|
 |---|---|
+|`date`|Produces a literal date as a string (format: YYYY-MM-DD).|
 |`int8`|Produces an integer.|
 |`interval`|Produces interval in seconds (integer).|
+|`numeric`|Produces a float.|
 |`timestamp`|Produces a unix timestamp (in milliseconds).|
 |`timestamptz`|Produces a unix timestamp (in milliseconds).|
 


### PR DESCRIPTION
`date` and `numeric` parsers are added by default but the doc is outdated

https://github.com/gajus/slonik/blob/1e84a0c733c364cfadbcd5d9fba2151a9c66bbf6/src/factories/createTypeParserPreset.js#L15