### PR TITLE
implement sql.timestamp

### DIFF
--- a/src/factories/createSqlTag.js
+++ b/src/factories/createSqlTag.js
@@ -11,6 +11,7 @@ import type {
   SqlSqlTokenType,
   SqlTaggedTemplateType,
   SqlTokenType,
+  TimestampSqlTokenType,
   UnnestSqlTokenType,
   ValueExpressionType,
 } from '../types';
@@ -27,6 +28,7 @@ import {
   JsonToken,
   ListToken,
   SqlToken,
+  TimestampToken,
   UnnestToken,
 } from '../tokens';
 import {
@@ -145,6 +147,15 @@ export default () => {
       glue,
       members,
       type: ListToken,
+    });
+  };
+
+  sql.timestamp = (
+    milliseconds: number,
+  ): TimestampSqlTokenType => {
+    return deepFreeze({
+      milliseconds,
+      type: TimestampToken,
     });
   };
 

--- a/src/factories/createSqlTokenSqlFragment.js
+++ b/src/factories/createSqlTokenSqlFragment.js
@@ -7,6 +7,7 @@ import {
   JsonToken,
   ListToken,
   SqlToken,
+  TimestampToken,
   UnnestToken,
 } from '../tokens';
 import {
@@ -16,6 +17,7 @@ import {
   createJsonSqlFragment,
   createListSqlFragment,
   createSqlSqlFragment,
+  createTimestampSqlFragment,
   createUnnestSqlFragment,
 } from '../sqlFragmentFactories';
 import {
@@ -39,6 +41,8 @@ export default (token: SqlTokenType, greatestParameterPosition: number): SqlFrag
     return createListSqlFragment(token, greatestParameterPosition);
   } else if (token.type === SqlToken) {
     return createSqlSqlFragment(token, greatestParameterPosition);
+  } else if (token.type === TimestampToken) {
+    return createTimestampSqlFragment(token, greatestParameterPosition);
   } else if (token.type === UnnestToken) {
     return createUnnestSqlFragment(token, greatestParameterPosition);
   }

--- a/src/sqlFragmentFactories/createTimestampSqlFragment.js
+++ b/src/sqlFragmentFactories/createTimestampSqlFragment.js
@@ -1,0 +1,22 @@
+// @flow
+
+import type {
+  TimestampSqlTokenType,
+  SqlFragmentType,
+} from '../types';
+import {
+  InvalidInputError,
+} from '../errors';
+
+export default (token: TimestampSqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
+  if (typeof token.milliseconds !== 'number') {
+    throw new InvalidInputError('sql.timestamp parameter must be a number (milliseconds since epoch)');
+  }
+
+  const sql = `to_timestamp($${ greatestParameterPosition + 1 })`;
+
+  return {
+    sql,
+    values: [token.milliseconds / 1000],
+  };
+};

--- a/src/sqlFragmentFactories/index.js
+++ b/src/sqlFragmentFactories/index.js
@@ -6,4 +6,5 @@ export {default as createIdentifierSqlFragment} from './createIdentifierSqlFragm
 export {default as createJsonSqlFragment} from './createJsonSqlFragment';
 export {default as createListSqlFragment} from './createListSqlFragment';
 export {default as createSqlSqlFragment} from './createSqlSqlFragment';
+export {default as createTimestampSqlFragment} from './createTimestampSqlFragment';
 export {default as createUnnestSqlFragment} from './createUnnestSqlFragment';

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -7,4 +7,5 @@ export const IdentifierToken = 'SLONIK_TOKEN_IDENTIFIER';
 export const JsonToken = 'SLONIK_TOKEN_JSON';
 export const ListToken = 'SLONIK_TOKEN_LIST';
 export const SqlToken = 'SLONIK_TOKEN_SQL';
+export const TimestampToken = 'SLONIK_TOKEN_TIMESTAMP';
 export const UnnestToken = 'SLONIK_TOKEN_UNNEST';

--- a/src/types.js
+++ b/src/types.js
@@ -279,6 +279,11 @@ export type SqlSqlTokenType = {|
   +values: $ReadOnlyArray<PrimitiveValueExpressionType>,
 |};
 
+export type TimestampSqlTokenType = {|
+  +milliseconds: number,
+  +type: 'SLONIK_TOKEN_TIMESTAMP',
+|};
+
 export type UnnestSqlTokenType = {|
   +columnTypes: $ReadOnlyArray<string>,
   +tuples: $ReadOnlyArray<$ReadOnlyArray<ValueExpressionType>>,
@@ -294,6 +299,7 @@ export type SqlTokenType =
   JsonSqlTokenType |
   ListSqlTokenType |
   SqlSqlTokenType |
+  TimestampSqlTokenType |
   UnnestSqlTokenType;
 
 export type ValueExpressionType =
@@ -337,6 +343,9 @@ export type SqlTaggedTemplateType = {|
     members: $ReadOnlyArray<ValueExpressionType>,
     glue: SqlTokenType,
   ) => ListSqlTokenType,
+  timestamp: (
+    milliseconds: number,
+  ) => TimestampSqlTokenType,
   unnest: (
 
     // Value might be $ReadOnlyArray<$ReadOnlyArray<PrimitiveValueExpressionType>>,

--- a/src/utilities/isSqlToken.js
+++ b/src/utilities/isSqlToken.js
@@ -8,6 +8,7 @@ import {
   JsonToken,
   ListToken,
   SqlToken,
+  TimestampToken,
   UnnestToken,
 } from '../tokens';
 
@@ -19,6 +20,7 @@ const Tokens = [
   JsonToken,
   ListToken,
   SqlToken,
+  TimestampToken,
   UnnestToken,
 ];
 

--- a/test/slonik/templateTags/sql/timestamp.js
+++ b/test/slonik/templateTags/sql/timestamp.js
@@ -1,0 +1,22 @@
+// @flow
+
+import test from 'ava';
+import createSqlTag from '../../../../src/factories/createSqlTag';
+import {
+  SqlToken,
+} from '../../../../src/tokens';
+
+const sql = createSqlTag();
+const moment = Date.parse('2000-01-01 00:00:00.000');
+
+test('creates a timestamp call', (t) => {
+  const query = sql`SELECT ${sql.timestamp(moment)}`;
+
+  t.deepEqual(query, {
+    sql: 'SELECT to_timestamp($1)',
+    type: SqlToken,
+    values: [
+      moment / 1000,
+    ],
+  });
+});


### PR DESCRIPTION
As proposed in #113, provide sql.timestamp function
that takes a millisecond argument and  wraps a call
to `to_timestamp`.

If this is accepted, I will work on the following steps:
 - have timestamp usable in `sql.unnest` (and possibly other constructs).
 - provide `sql.date` that takes a Date argument and forwards to `sql.timestamp`.
