### PR TITLE
Fix rows => columns typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1485,7 +1485,7 @@ const rows = await connection.any(sql`SELECT foo`);
 
 Returns value of the first column of every row in the result set.
 
-* Throws `DataIntegrityError` if query returns multiple rows.
+* Throws `DataIntegrityError` if query returns multiple columns.
 
 Example:
 


### PR DESCRIPTION
anyFirst throws when multiple **columns**, not **rows**


NB: I have no clue why this PR shows a deletion in [here](https://github.com/gajus/slonik/compare/master...cyrilchapon:patch-3#diff-04c6e90faac2675aa89e2176d2eec7d8L2099). I edited on Chrome directly on Github, thrice, repeating from fresh master. That's strange