### PR TITLE
feat(logging): allow passing roarr instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2137,6 +2137,31 @@ By default, Slonik logs only connection events, e.g. when connection is created,
 
 Query-level logging can be added using [`slonik-interceptor-query-logging`](https://github.com/gajus/slonik-interceptor-query-logging) interceptor.
 
+To include application-specific log context, pass in a `roarr` instance to the `createPool` parameters. You can also use `withLogContext` on an existing pool. For example in an http server request handler:
+
+```js
+import roarr from 'roarr';
+import { createPool, sql } from 'slonik';
+
+const appLogger = roarr.child({
+  appName: 'my-app',
+  appVersion: 'v1.2.3',
+});
+
+const pool = createPool(process.env.POSTGRES_CONNECTION_STRING, {
+  logger: appLogger,
+});
+
+export const handler = async (req, res) => {
+  const slonik = pool.withLogContext({
+    requestId: req.headers['x-request-id'],
+  });
+
+  const results = await slonik.any(sql`SELECT ...`);
+  res.status(200).send(results);
+};
+```
+
 <a name="slonik-debugging-capture-stack-trace"></a>
 ### Capture stack trace
 

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -3,7 +3,7 @@
 import Roarr from 'roarr';
 
 export const getLogger = (logger: typeof Roarr) => (logger || Roarr).child({
-  package: logger?.getContext().package || 'slonik',
+  package: 'slonik',
 });
 
 export default getLogger();

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,7 +1,9 @@
 // @flow
 
-import Logger from 'roarr';
+import Roarr from 'roarr';
 
-export default Logger.child({
-  package: 'slonik',
+export const getLogger = (logger: typeof Roarr) => (logger || Roarr).child({
+  package: logger?.getContext().package || 'slonik',
 });
+
+export default getLogger();

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -2,7 +2,7 @@
 
 import Roarr from 'roarr';
 
-export const getLogger = (logger: typeof Roarr) => (logger || Roarr).child({
+export const getLogger = (logger?: typeof Roarr) => (logger || Roarr).child({
   package: 'slonik',
 });
 

--- a/src/binders/bindPool.js
+++ b/src/binders/bindPool.js
@@ -16,9 +16,8 @@ import {
 import {
   assertSqlSqlToken,
 } from '../assertions';
-import {bindPool} from '.';
 
-export default (
+const bindPool = (
   parentLog: LoggerType,
   pool: InternalDatabasePoolType,
   clientConfiguration: ClientConfigurationType,
@@ -162,3 +161,5 @@ export default (
     withLogContext: (context) => bindPool(parentLog.child(context), pool, clientConfiguration)
   };
 };
+
+export default bindPool;

--- a/src/binders/bindPool.js
+++ b/src/binders/bindPool.js
@@ -16,6 +16,7 @@ import {
 import {
   assertSqlSqlToken,
 } from '../assertions';
+import {bindPool} from '.';
 
 export default (
   parentLog: LoggerType,
@@ -158,5 +159,6 @@ export default (
         },
       );
     },
+    withLogContext: (context) => bindPool(parentLog.child(context), pool, clientConfiguration)
   };
 };

--- a/src/factories/createClientConfiguration.js
+++ b/src/factories/createClientConfiguration.js
@@ -30,7 +30,7 @@ export default (clientUserConfigurationInput?: ClientConfigurationInputType): Cl
     statementTimeout: 60000,
     transactionRetryLimit: 5,
     typeParsers,
-    logger: getLogger(clientUserConfigurationInput?.logger)
+    logger: getLogger(clientUserConfigurationInput?.logger),
 
     // $FlowFixMe
     ...clientUserConfigurationInput,

--- a/src/factories/createClientConfiguration.js
+++ b/src/factories/createClientConfiguration.js
@@ -9,6 +9,7 @@ import {
   InvalidConfigurationError,
 } from '../errors';
 import createTypeParserPreset from './createTypeParserPreset';
+import {getLogger} from '../Logger';
 
 export default (clientUserConfigurationInput?: ClientConfigurationInputType): ClientConfigurationType => {
   const typeParsers: $ReadOnlyArray<TypeParserType> = [];
@@ -29,6 +30,7 @@ export default (clientUserConfigurationInput?: ClientConfigurationInputType): Cl
     statementTimeout: 60000,
     transactionRetryLimit: 5,
     typeParsers,
+    logger: getLogger(clientUserConfigurationInput?.logger)
 
     // $FlowFixMe
     ...clientUserConfigurationInput,

--- a/src/factories/createMockPool.js
+++ b/src/factories/createMockPool.js
@@ -10,7 +10,6 @@ import type {
   QueryResultRowType,
   QueryResultType,
 } from '../types';
-import Logger from '../Logger';
 import bindPool from '../binders/bindPool';
 import createClientConfiguration from './createClientConfiguration';
 
@@ -26,7 +25,7 @@ export default (
 
   const poolId = createUlid();
 
-  const poolLog = Logger.child({
+  const poolLog = clientConfiguration.logger.child({
     poolId,
   });
 

--- a/src/factories/createPool.js
+++ b/src/factories/createPool.js
@@ -10,7 +10,6 @@ import type {
   ClientConfigurationInputType,
   DatabasePoolType,
 } from '../types';
-import Logger from '../Logger';
 import bindPool from '../binders/bindPool';
 import createClientConfiguration from './createClientConfiguration';
 import createPoolConfiguration from './createPoolConfiguration';
@@ -26,7 +25,7 @@ export default (
 
   const poolId = createUlid();
 
-  const poolLog = Logger.child({
+  const poolLog = clientConfiguration.logger.child({
     poolId,
   });
 

--- a/src/factories/createPoolConfiguration.js
+++ b/src/factories/createPoolConfiguration.js
@@ -8,10 +8,11 @@ import {
 import type {
   ClientConfigurationType,
 } from '../types';
-import log from '../Logger';
 
 export default (connectionUri: string, clientConfiguration: ClientConfigurationType) => {
   const poolConfiguration = parseConnectionString(connectionUri);
+
+  const log = clientConfiguration.logger;
 
   // @see https://node-postgres.com/api/pool
   poolConfiguration.connectionTimeoutMillis = clientConfiguration.connectionTimeout;

--- a/src/types.js
+++ b/src/types.js
@@ -90,6 +90,7 @@ export type ClientConfigurationInputType = {|
   +statementTimeout?: number | 'DISABLE_TIMEOUT',
   +transactionRetryLimit?: number,
   +typeParsers?: $ReadOnlyArray<TypeParserType>,
+  +logger?: LoggerType,
 |};
 
 export type ClientConfigurationType = {|
@@ -104,6 +105,7 @@ export type ClientConfigurationType = {|
   +statementTimeout: number | 'DISABLE_TIMEOUT',
   +transactionRetryLimit: number,
   +typeParsers: $ReadOnlyArray<TypeParserType>,
+  +logger: LoggerType,
 |};
 
 export type StreamFunctionType = (

--- a/src/types.js
+++ b/src/types.js
@@ -168,6 +168,7 @@ export type DatabasePoolType = {|
   +getPoolState: () => PoolStateType,
   +stream: StreamFunctionType,
   +transaction: (handler: TransactionFunctionType) => Promise<*>,
+  +withLogContext: (context: object) => DatabasePoolType,
 |};
 
 /**

--- a/test/helpers/createPool.js
+++ b/test/helpers/createPool.js
@@ -54,6 +54,8 @@ export const createPoolInternal = (clientConfiguration: ClientConfigurationInput
 export default (clientConfiguration: ClientConfigurationInputType = defaultConfiguration) => {
   const internalPool = createPoolInternal(clientConfiguration);
 
+  const connection = internalPool.connect();
+
   const connectSpy = sinon.spy(internalPool, 'connect');
   const endSpy = sinon.spy(connection, 'end');
   const querySpy = sinon.stub(connection, 'query').returns({});

--- a/test/helpers/createPool.js
+++ b/test/helpers/createPool.js
@@ -15,7 +15,7 @@ const defaultConfiguration = {
   typeParsers: [],
 };
 
-export const createPoolInternal = (clientConfiguration: ClientConfigurationInputType = defaultConfiguration) => {
+export default (clientConfiguration: ClientConfigurationInputType = defaultConfiguration) => {
   const eventEmitter = new EventEmitter();
 
   const connection = {
@@ -37,7 +37,7 @@ export const createPoolInternal = (clientConfiguration: ClientConfigurationInput
     release: () => {},
   };
 
-  return {
+  const internalPool = {
     _pulseQueue: () => {},
     _remove: () => {},
     connect: () => {
@@ -49,12 +49,6 @@ export const createPoolInternal = (clientConfiguration: ClientConfigurationInput
       poolId: '1',
     },
   };
-};
-
-export default (clientConfiguration: ClientConfigurationInputType = defaultConfiguration) => {
-  const internalPool = createPoolInternal(clientConfiguration);
-
-  const connection = internalPool.connect();
 
   const connectSpy = sinon.spy(internalPool, 'connect');
   const endSpy = sinon.spy(connection, 'end');
@@ -78,8 +72,7 @@ export default (clientConfiguration: ClientConfigurationInputType = defaultConfi
     },
   );
 
-  return {
-    ...pool,
+  const helpers = {
     connection,
     connectSpy,
     endSpy,
@@ -87,4 +80,9 @@ export default (clientConfiguration: ClientConfigurationInputType = defaultConfi
     releaseSpy,
     removeSpy,
   };
+
+  Object.keys(helpers).forEach(prop => {
+    Object.defineProperty(pool, prop, { value: helpers[prop], enumerable: false });
+  });
+  return pool;
 };

--- a/test/helpers/createPool.js
+++ b/test/helpers/createPool.js
@@ -15,7 +15,7 @@ const defaultConfiguration = {
   typeParsers: [],
 };
 
-export default (clientConfiguration: ClientConfigurationInputType = defaultConfiguration) => {
+export const createPoolInternal = (clientConfiguration: ClientConfigurationInputType = defaultConfiguration) => {
   const eventEmitter = new EventEmitter();
 
   const connection = {
@@ -37,7 +37,7 @@ export default (clientConfiguration: ClientConfigurationInputType = defaultConfi
     release: () => {},
   };
 
-  const internalPool = {
+  return {
     _pulseQueue: () => {},
     _remove: () => {},
     connect: () => {
@@ -49,6 +49,10 @@ export default (clientConfiguration: ClientConfigurationInputType = defaultConfi
       poolId: '1',
     },
   };
+};
+
+export default (clientConfiguration: ClientConfigurationInputType = defaultConfiguration) => {
+  const internalPool = createPoolInternal(clientConfiguration);
 
   const connectSpy = sinon.spy(internalPool, 'connect');
   const endSpy = sinon.spy(connection, 'end');

--- a/test/slonik/binders/bindPool/logger.js
+++ b/test/slonik/binders/bindPool/logger.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { createPoolInternal } from '../../../helpers/createPool';
+import createPool from '../../../helpers/createPool';
 import { inspect } from 'util';
 
 test('withLogContext returns a new pool', async (t) => {

--- a/test/slonik/binders/bindPool/logger.js
+++ b/test/slonik/binders/bindPool/logger.js
@@ -1,0 +1,10 @@
+import test from 'ava';
+import { createPoolInternal } from '../../../helpers/createPool';
+import { inspect } from 'util';
+
+test('withLogContext returns a new pool', async (t) => {
+  const original = createPool();
+  const modified = original.withLogContext({ foo: 'bar' });
+
+  t.deepEqual(inspect(modified), inspect(original));
+});


### PR DESCRIPTION
related: https://github.com/gajus/slonik/issues/119

This will allow taking advantage of slonik's default logging, as well as packages like [slonik-interceptor-query-logging](https://github.com/gajus/slonik-interceptor-query-logging) to log full queries, at the same time as passing in existing application context (e.g. the incoming http headers for the request that triggered a sql query), by letting users pass in their own roarr instance into `createPool`.

Some notes/questions:

- ~to take advantage of this and pass in per-request context, it'd mean calling `createPool` once per request. It's a little hard to tell whether that will be an expensive operation or have any negative side-effects - [lines like this make me a little uneasy](https://github.com/gajus/slonik/blob/b29afbb6420f59e5d8584a9ea466921e2fe21c56/src/factories/createPool.js#L40). If it is, I could move the logger injection further down (maybe to `bindPool.js`, which looks like it only sets up some lazy methods), but it'd be a slightly bigger code change/API surface change, so I thought I'd check first.~
  - added a `withLogContext` method to `DatabasePoolType`, and `bindPool` implements it by simply recursively calling itself, with the logger argument modified using `parentLog.child`. This allows passing in a custom logger with application-level information to `createPool` (e.g. `roarr.child({ appName: 'booking-service', appVersion: 'v1.2.3' })`, but for individual requests, it's possible to call `myPool.withLogContext({ requestId: 'abc123' })` to get a cheap pool reference, with a new logger, without the potential side-effects of calling `createPool` many times.
- this isn't the full story in addressing the ask from @moltar in https://github.com/gajus/slonik/issues/119 - it would also be nice to be slightly less bound by roarr's design decisions. There's nothing I can see that's wrong with roarr at all, but I'm looking to integrate slonik into an existing project with a custom logging framework. We are fully in control of what gets printed to stdout, so wouldn't be comfortable turning on the potential `ROARR_LOG=true` firehose. For that reason, I may follow this up with a roarr PR that allows passing in a custom `onMessage` function to a roarr instance, to allow interop with custom logging libraries (which would hopefully cover @moltar's use-case of wanting special formatting for integration tests - shared by my team, too, in fact).

TODO:
- [x] unit tests
- [x] documentation of new parameter