### PR TITLE
Allow sql.json to encode primitive values

### DIFF
--- a/src/sqlFragmentFactories/createJsonSqlFragment.js
+++ b/src/sqlFragmentFactories/createJsonSqlFragment.js
@@ -27,7 +27,7 @@ export default (token: JsonSqlTokenType, greatestParameterPosition: number): Sql
 
   // @todo Deep check Array.
   // eslint-disable-next-line no-negated-condition
-  } else if (!isPlainObject(token.value) && !Array.isArray(token.value)) {
+  } else if (!isPlainObject(token.value) && !Array.isArray(token.value) && !['number', 'string', 'boolean'].includes(typeof token.value)) {
     throw new InvalidInputError('JSON payload must be a primitive value or a plain object.');
   } else {
     try {

--- a/test/slonik/templateTags/sql/json.js
+++ b/test/slonik/templateTags/sql/json.js
@@ -44,6 +44,42 @@ test('passes null unstringified', (t) => {
   });
 });
 
+test('JSON encodes string values', (t) => {
+  const query = sql`SELECT ${sql.json('example string')}`;
+
+  t.deepEqual(query, {
+    sql: 'SELECT $1',
+    type: SqlToken,
+    values: [
+      '"example string"',
+    ],
+  });
+});
+
+test('JSON encodes numeric values', (t) => {
+  const query = sql`SELECT ${sql.json(1234)}`;
+
+  t.deepEqual(query, {
+    sql: 'SELECT $1',
+    type: SqlToken,
+    values: [
+      '1234',
+    ],
+  });
+});
+
+test('JSON encodes boolean values', (t) => {
+  const query = sql`SELECT ${sql.json(true)}`;
+
+  t.deepEqual(query, {
+    sql: 'SELECT $1',
+    type: SqlToken,
+    values: [
+      'true',
+    ],
+  });
+});
+
 test('throws if payload is undefined', (t) => {
   const error = t.throws(() => {
     // $FlowFixMe


### PR DESCRIPTION
I was working on something that took a passed unknown value (typed as `SerializableValueType`) and would write/read it from the database. I noticed that things worked fine for complex javascript objects/arrrays like `[{foo: 'bar'}]` but not when I passed in a string. This problem only occurred when I was using `sql.json` to encode the value. If I manually called `JSON.stringify` on the value, then it would be inserted into the database successfully.

I investigated and am providing this patch