### PR TITLE
build on prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "url": "https://github.com/gajus/slonik"
   },
   "scripts": {
+    "prepare": "npm run build",
     "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --copy-files --source-maps && flow-copy-source src dist",
     "create-readme": "gitdown ./.README/README.md --output-file ./README.md",
     "lint": "eslint ./src ./test && flow",


### PR DESCRIPTION
If installing a specific revision of this library as a dependency, the package isn't built.

This should fix this so it's possible to do something like:

`yarn add https://github.com/gajus/slonik#some-git-rev-hash`