### PR TITLE
fix: expose cursor result property on query stream

### DIFF
--- a/src/connectionMethods/stream.js
+++ b/src/connectionMethods/stream.js
@@ -27,9 +27,7 @@ const stream: InternalStreamFunctionType = async (connectionLogger, connection, 
         throw new UnexpectedStateError('Result cursors do not work with the native driver. Use JavaScript driver.');
       }
 
-      const query = new QueryStream(finalSql, finalValues, {
-        types: finalConnection._types,
-      });
+      const query = new QueryStream(finalSql, finalValues);
 
       const queryStream = finalConnection.query(query);
 


### PR DESCRIPTION
This is the more elegant fix for https://github.com/gajus/slonik/issues/189

I have reversed changes from https://github.com/gajus/slonik/pull/190 and added this fix:
https://github.com/brianc/node-postgres/pull/2271/files