### PR TITLE
Preserve ssl configuration in connection string

### DIFF
--- a/src/factories/createPoolConfiguration.js
+++ b/src/factories/createPoolConfiguration.js
@@ -29,6 +29,7 @@ export default (connectionUri: string, clientConfiguration: ClientConfigurationT
   if (poolConfiguration.ssl) {
     poolConfiguration.ssl = {
       rejectUnauthorized: false,
+      ...poolConfiguration.ssl,
     };
   }
 


### PR DESCRIPTION
A connection string may contain ssl related query parameters. For
example: 'sslcert=/path/tocert'. This will add the contents of the
certificate to { ssl: { cert: '...' } }.

We continue to default rejectUnauthorized if ssl is turned on, but now
we respect all ssl configuration settings specified in the connection
string.