### PR TITLE
Return native BigInt in the big int parser

### DIFF
--- a/src/factories/typeParsers/createBigintTypeParser.js
+++ b/src/factories/typeParsers/createBigintTypeParser.js
@@ -5,8 +5,7 @@ import type {
 } from '../../types';
 
 const bigintParser = (value) => {
-  // @todo Use bigint when value is greater than Number.MAX_SAFE_INTEGER.
-  return Number.parseInt(value, 10);
+  return BigInt(value);
 };
 
 export default (): TypeParserType => {


### PR DESCRIPTION
This is a breaking change because `BigInt`s don't always mix well with `Number`s. For example the following will throw an error:

```js
BigInt(1) + 1; // Uncaught TypeError: Cannot mix BigInt and other types, use explicit conversions
```

I think the backwards compatibility musn't be kept: if all numbers <= `Number.MAX_SAFE_INTEGER` were regular `Number`s while the greater ones were `BigInt`s, in most cases the user would have to do a `typeof` every time before using their number to cast it to the proper type for their calculation.