### PR TITLE
TypeScript: convert default exports to named

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
     "linebreak-style": 0,
     // https://github.com/typescript-eslint/typescript-eslint/issues/1624#issuecomment-589731039
     "import/no-unresolved": 0,
+    "import/no-default-export": 1,
     "no-extra-parens": 0,
     "no-unused-vars": 0,
     "@typescript-eslint/no-unused-vars": 1,
@@ -47,6 +48,7 @@
       "files": "*.d.ts",
       "rules": {
         "filenames/match-regex": 0,
+        "import/no-default-export": 0,
         "import/unambiguous": 0
       }
     }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "semantic-release": "^17.2.1",
     "sinon": "^9.2.0",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.3"
+    "typescript": "^4.1.0-beta"
   },
   "engines": {
     "node": ">=10.0"

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,7 +1,7 @@
 // @flow
 
-import Logger from 'roarr';
+import roarr from 'roarr';
 
-export default Logger.child({
+export const Logger = roarr.child({
   package: 'slonik',
 });

--- a/src/QueryStream.ts
+++ b/src/QueryStream.ts
@@ -16,7 +16,7 @@ import Cursor from 'pg-cursor';
  * @see https://github.com/brianc/node-pg-query-stream
  * @see https://github.com/brianc/node-pg-query-stream/issues/51
  */
-export default class QueryStream extends Readable {
+export class QueryStream extends Readable {
   _reading: boolean;
 
   _closed: boolean;

--- a/src/binders/bindPool.ts
+++ b/src/binders/bindPool.ts
@@ -17,7 +17,7 @@ import type {
   TaggedTemplateLiteralInvocationType,
 } from '../types';
 
-export default (
+export const bindPool = (
   parentLog: LoggerType,
   pool: InternalDatabasePoolType,
   clientConfiguration: ClientConfigurationType,

--- a/src/binders/bindPoolConnection.ts
+++ b/src/binders/bindPoolConnection.ts
@@ -28,7 +28,7 @@ import {
   mapTaggedTemplateLiteralInvocation,
 } from '../utilities';
 
-export default (
+export const bindPoolConnection = (
   parentLog: LoggerType,
   connection: InternalDatabaseConnectionType,
   clientConfiguration: ClientConfigurationType,

--- a/src/binders/bindTransactionConnection.ts
+++ b/src/binders/bindTransactionConnection.ts
@@ -24,7 +24,7 @@ import {
   mapTaggedTemplateLiteralInvocation,
 } from '../utilities';
 
-export default (
+export const bindTransactionConnection = (
   parentLog: LoggerType,
   connection: InternalDatabaseConnectionType,
   clientConfiguration: ClientConfigurationType,

--- a/src/binders/index.ts
+++ b/src/binders/index.ts
@@ -1,11 +1,11 @@
 // @flow
 
 export {
-  default as bindPool,
+  bindPool,
 } from './bindPool';
 export {
-  default as bindPoolConnection,
+  bindPoolConnection,
 } from './bindPoolConnection';
 export {
-  default as bindTransactionConnection,
+  bindTransactionConnection,
 } from './bindTransactionConnection';

--- a/src/connectionMethods/any.ts
+++ b/src/connectionMethods/any.ts
@@ -6,12 +6,14 @@ import type {
 import {
   createQueryId,
 } from '../utilities';
-import query from './query';
+import {
+  query,
+} from './query';
 
 /**
  * Makes a query and expects any number of results.
  */
-const any: InternalQueryMethods['any'] = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const any: InternalQueryMethods['any'] = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
   const queryId = inheritedQueryId || createQueryId();
 
   const {
@@ -20,5 +22,3 @@ const any: InternalQueryMethods['any'] = async (log, connection, clientConfigura
 
   return rows;
 };
-
-export default any;

--- a/src/connectionMethods/anyFirst.ts
+++ b/src/connectionMethods/anyFirst.ts
@@ -9,9 +9,11 @@ import type {
 import {
   createQueryId,
 } from '../utilities';
-import any from './any';
+import {
+  any,
+} from './any';
 
-const anyFirst: InternalQueryMethods['anyFirst'] = async (log, connection, clientConfigurationType, rawSql, values, inheritedQueryId) => {
+export const anyFirst: InternalQueryMethods['anyFirst'] = async (log, connection, clientConfigurationType, rawSql, values, inheritedQueryId) => {
   const queryId = inheritedQueryId || createQueryId();
 
   const rows = await any(log, connection, clientConfigurationType, rawSql, values, queryId);
@@ -38,5 +40,3 @@ const anyFirst: InternalQueryMethods['anyFirst'] = async (log, connection, clien
     return row[firstColumnName];
   });
 };
-
-export default anyFirst;

--- a/src/connectionMethods/copyFromBinary.ts
+++ b/src/connectionMethods/copyFromBinary.ts
@@ -28,7 +28,7 @@ const bufferToStream = (buffer: Buffer) => {
   return stream;
 };
 
-const copyFromBinary: InternalCopyFromBinaryFunctionType = async (
+export const copyFromBinary: InternalCopyFromBinaryFunctionType = async (
   connectionLogger,
   connection,
   clientConfiguration,
@@ -68,5 +68,3 @@ const copyFromBinary: InternalCopyFromBinaryFunctionType = async (
     },
   );
 };
-
-export default copyFromBinary;

--- a/src/connectionMethods/exists.ts
+++ b/src/connectionMethods/exists.ts
@@ -9,9 +9,11 @@ import type {
 import {
   createQueryId,
 } from '../utilities';
-import query from './query';
+import {
+  query,
+} from './query';
 
-const exists: InternalQueryMethods['exists'] = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const exists: InternalQueryMethods['exists'] = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
   const queryId = inheritedQueryId || createQueryId();
 
   const {
@@ -28,5 +30,3 @@ const exists: InternalQueryMethods['exists'] = async (log, connection, clientCon
 
   return Boolean((rows[0] as Record<string, unknown>).exists);
 };
-
-export default exists;

--- a/src/connectionMethods/index.ts
+++ b/src/connectionMethods/index.ts
@@ -1,44 +1,44 @@
 // @flow
 
 export {
-  default as any,
+  any,
 } from './any';
 export {
-  default as anyFirst,
+  anyFirst,
 } from './anyFirst';
 export {
-  default as exists,
+  exists,
 } from './exists';
 export {
-  default as copyFromBinary,
+  copyFromBinary,
 } from './copyFromBinary';
 export {
-  default as many,
+  many,
 } from './many';
 export {
-  default as manyFirst,
+  manyFirst,
 } from './manyFirst';
 export {
-  default as maybeOne,
+  maybeOne,
 } from './maybeOne';
 export {
-  default as maybeOneFirst,
+  maybeOneFirst,
 } from './maybeOneFirst';
 export {
-  default as nestedTransaction,
+  nestedTransaction,
 } from './nestedTransaction';
 export {
-  default as one,
+  one,
 } from './one';
 export {
-  default as oneFirst,
+  oneFirst,
 } from './oneFirst';
 export {
-  default as query,
+  query,
 } from './query';
 export {
-  default as stream,
+  stream,
 } from './stream';
 export {
-  default as transaction,
+  transaction,
 } from './transaction';

--- a/src/connectionMethods/many.ts
+++ b/src/connectionMethods/many.ts
@@ -9,14 +9,16 @@ import type {
 import {
   createQueryId,
 } from '../utilities';
-import query from './query';
+import {
+  query,
+} from './query';
 
 /**
  * Makes a query and expects at least 1 result.
  *
  * @throws NotFoundError If query returns no rows.
  */
-const many: InternalQueryMethods['many'] = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const many: InternalQueryMethods['many'] = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
   const queryId = inheritedQueryId || createQueryId();
 
   const {
@@ -33,5 +35,3 @@ const many: InternalQueryMethods['many'] = async (log, connection, clientConfigu
 
   return rows;
 };
-
-export default many;

--- a/src/connectionMethods/manyFirst.ts
+++ b/src/connectionMethods/manyFirst.ts
@@ -9,9 +9,11 @@ import type {
 import {
   createQueryId,
 } from '../utilities';
-import many from './many';
+import {
+  many,
+} from './many';
 
-const manyFirst: InternalQueryMethods['manyFirst'] = async (log, connection, clientConfigurationType, rawSql, values, inheritedQueryId) => {
+export const manyFirst: InternalQueryMethods['manyFirst'] = async (log, connection, clientConfigurationType, rawSql, values, inheritedQueryId) => {
   const queryId = inheritedQueryId || createQueryId();
 
   const rows = await many(log, connection, clientConfigurationType, rawSql, values, queryId);
@@ -40,5 +42,3 @@ const manyFirst: InternalQueryMethods['manyFirst'] = async (log, connection, cli
     return row[firstColumnName];
   });
 };
-
-export default manyFirst;

--- a/src/connectionMethods/maybeOne.ts
+++ b/src/connectionMethods/maybeOne.ts
@@ -9,14 +9,16 @@ import type {
 import {
   createQueryId,
 } from '../utilities';
-import query from './query';
+import {
+  query,
+} from './query';
 
 /**
  * Makes a query and expects exactly one result.
  *
  * @throws DataIntegrityError If query returns multiple rows.
  */
-const maybeOne: InternalQueryMethods['maybeOne'] = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const maybeOne: InternalQueryMethods['maybeOne'] = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
   const queryId = inheritedQueryId || createQueryId();
 
   const {
@@ -37,5 +39,3 @@ const maybeOne: InternalQueryMethods['maybeOne'] = async (log, connection, clien
 
   return rows[0];
 };
-
-export default maybeOne;

--- a/src/connectionMethods/maybeOneFirst.ts
+++ b/src/connectionMethods/maybeOneFirst.ts
@@ -9,7 +9,9 @@ import type {
 import {
   createQueryId,
 } from '../utilities';
-import maybeOne from './maybeOne';
+import {
+  maybeOne,
+} from './maybeOne';
 
 /**
  * Makes a query and expects exactly one result.
@@ -17,7 +19,7 @@ import maybeOne from './maybeOne';
  *
  * @throws DataIntegrityError If query returns multiple rows.
  */
-const maybeOneFirst: InternalQueryMethods['maybeOneFirst'] = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const maybeOneFirst: InternalQueryMethods['maybeOneFirst'] = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
   const queryId = inheritedQueryId || createQueryId();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -39,5 +41,3 @@ const maybeOneFirst: InternalQueryMethods['maybeOneFirst'] = async (log, connect
 
   return row[keys[0]];
 };
-
-export default maybeOneFirst;

--- a/src/connectionMethods/nestedTransaction.ts
+++ b/src/connectionMethods/nestedTransaction.ts
@@ -13,7 +13,7 @@ import {
   createUlid,
 } from '../utilities';
 
-const nestedTransaction: InternalNestedTransactionFunctionType = async (parentLog, connection, clientConfiguration, handler, transactionDepth) => {
+export const nestedTransaction: InternalNestedTransactionFunctionType = async (parentLog, connection, clientConfiguration, handler, transactionDepth) => {
   const newTransactionDepth = transactionDepth + 1;
 
   if (connection.connection.slonik.mock === false) {
@@ -44,5 +44,3 @@ const nestedTransaction: InternalNestedTransactionFunctionType = async (parentLo
     connection.connection.slonik.transactionDepth = newTransactionDepth - 1;
   }
 };
-
-export default nestedTransaction;

--- a/src/connectionMethods/one.ts
+++ b/src/connectionMethods/one.ts
@@ -10,7 +10,9 @@ import type {
 import {
   createQueryId,
 } from '../utilities';
-import query from './query';
+import {
+  query,
+} from './query';
 
 /**
  * Makes a query and expects exactly one result.
@@ -18,7 +20,7 @@ import query from './query';
  * @throws NotFoundError If query returns no rows.
  * @throws DataIntegrityError If query returns multiple rows.
  */
-const one: InternalQueryMethods['one'] = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const one: InternalQueryMethods['one'] = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
   const queryId = inheritedQueryId || createQueryId();
 
   const {
@@ -43,5 +45,3 @@ const one: InternalQueryMethods['one'] = async (log, connection, clientConfigura
 
   return rows[0];
 };
-
-export default one;

--- a/src/connectionMethods/oneFirst.ts
+++ b/src/connectionMethods/oneFirst.ts
@@ -9,7 +9,9 @@ import type {
 import {
   createQueryId,
 } from '../utilities';
-import one from './one';
+import {
+  one,
+} from './one';
 
 /**
  * Makes a query and expects exactly one result.
@@ -18,7 +20,7 @@ import one from './one';
  * @throws NotFoundError If query returns no rows.
  * @throws DataIntegrityError If query returns multiple rows.
  */
-const oneFirst: InternalQueryMethods['oneFirst'] = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const oneFirst: InternalQueryMethods['oneFirst'] = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
   const queryId = inheritedQueryId || createQueryId();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -36,5 +38,3 @@ const oneFirst: InternalQueryMethods['oneFirst'] = async (log, connection, clien
 
   return row[keys[0]];
 };
-
-export default oneFirst;

--- a/src/connectionMethods/query.ts
+++ b/src/connectionMethods/query.ts
@@ -12,7 +12,7 @@ import type {
   QueryResultType,
 } from '../types';
 
-const query: InternalQueryMethods['query'] = async (connectionLogger, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const query: InternalQueryMethods['query'] = async (connectionLogger, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
   return executeQuery(
     connectionLogger,
     connection,
@@ -38,5 +38,3 @@ const query: InternalQueryMethods['query'] = async (connectionLogger, connection
     },
   );
 };
-
-export default query;

--- a/src/connectionMethods/stream.ts
+++ b/src/connectionMethods/stream.ts
@@ -4,7 +4,9 @@
 
 import type Stream from 'stream';
 import through from 'through2';
-import QueryStream from '../QueryStream';
+import {
+  QueryStream,
+} from '../QueryStream';
 import {
   UnexpectedStateError,
 } from '../errors';
@@ -16,7 +18,7 @@ import type {
   InternalStreamFunctionType,
 } from '../types';
 
-const stream: InternalStreamFunctionType = async (connectionLogger, connection, clientConfiguration, rawSql, values, streamHandler) => {
+export const stream: InternalStreamFunctionType = async (connectionLogger, connection, clientConfiguration, rawSql, values, streamHandler) => {
   return executeQuery(
     connectionLogger,
     connection,
@@ -81,5 +83,3 @@ const stream: InternalStreamFunctionType = async (connectionLogger, connection, 
     },
   );
 };
-
-export default stream;

--- a/src/connectionMethods/transaction.ts
+++ b/src/connectionMethods/transaction.ts
@@ -17,7 +17,7 @@ import {
   createUlid,
 } from '../utilities';
 
-const transaction: InternalTransactionFunctionType = async (parentLog, connection, clientConfiguration, handler) => {
+export const transaction: InternalTransactionFunctionType = async (parentLog, connection, clientConfiguration, handler) => {
   if (connection.connection.slonik.transactionDepth !== null) {
     throw new UnexpectedStateError('Cannot use the same connection to start a new transaction before completing the last transaction.');
   }
@@ -69,5 +69,3 @@ const transaction: InternalTransactionFunctionType = async (parentLog, connectio
     connection.connection.slonik.transactionQueries = null;
   }
 };
-
-export default transaction;

--- a/src/factories/createClientConfiguration.ts
+++ b/src/factories/createClientConfiguration.ts
@@ -8,9 +8,11 @@ import type {
   ClientConfigurationType,
   TypeParserType,
 } from '../types';
-import createTypeParserPreset from './createTypeParserPreset';
+import {
+  createTypeParserPreset,
+} from './createTypeParserPreset';
 
-export default (clientUserConfigurationInput?: ClientConfigurationInputType): ClientConfigurationType => {
+export const createClientConfiguration = (clientUserConfigurationInput?: ClientConfigurationInputType): ClientConfigurationType => {
   const typeParsers: readonly TypeParserType[] = [];
 
   const configuration = {

--- a/src/factories/createConnection.ts
+++ b/src/factories/createConnection.ts
@@ -49,7 +49,7 @@ const terminatePoolConnection = (pool: any, connection: any, error: any) => {
 };
 
 // eslint-disable-next-line complexity
-const createConnection = async (
+export const createConnection = async (
   parentLog: LoggerType,
   pool: InternalDatabasePoolType,
   clientConfiguration: ClientConfigurationType,
@@ -198,5 +198,3 @@ const createConnection = async (
 
   return result;
 };
-
-export default createConnection;

--- a/src/factories/createMockPool.ts
+++ b/src/factories/createMockPool.ts
@@ -1,7 +1,11 @@
 // @flow
 
-import Logger from '../Logger';
-import bindPool from '../binders/bindPool';
+import {
+  Logger,
+} from '../Logger';
+import {
+  bindPool,
+} from '../binders/bindPool';
 import type {
   ClientConfigurationInputType,
   DatabasePoolType,
@@ -12,13 +16,15 @@ import type {
 import {
   createUlid,
 } from '../utilities';
-import createClientConfiguration from './createClientConfiguration';
+import {
+  createClientConfiguration,
+} from './createClientConfiguration';
 
 type OverridesType = {
   readonly query: (sql: string, values: ReadonlyArray<PrimitiveValueExpressionType>) => Promise<QueryResultType<QueryResultRowType>>;
 };
 
-export default (
+export const createMockPool = (
   overrides: OverridesType,
   clientConfigurationInput?: ClientConfigurationInputType,
 ): DatabasePoolType => {

--- a/src/factories/createMockQueryResult.ts
+++ b/src/factories/createMockQueryResult.ts
@@ -5,7 +5,7 @@ import type {
   QueryResultType,
 } from '../types';
 
-export default (rows: ReadonlyArray<QueryResultRowType>): QueryResultType<QueryResultRowType> => {
+export const createMockQueryResult = (rows: ReadonlyArray<QueryResultRowType>): QueryResultType<QueryResultRowType> => {
   return {
     command: 'SELECT',
     fields: [],

--- a/src/factories/createPool.ts
+++ b/src/factories/createPool.ts
@@ -8,8 +8,12 @@ import type pgTypes from 'pg';
 import {
   serializeError,
 } from 'serialize-error';
-import Logger from '../Logger';
-import bindPool from '../binders/bindPool';
+import {
+  Logger,
+} from '../Logger';
+import {
+  bindPool,
+} from '../binders/bindPool';
 import type {
   ClientConfigurationInputType,
   DatabasePoolType,
@@ -17,13 +21,17 @@ import type {
 import {
   createUlid,
 } from '../utilities';
-import createClientConfiguration from './createClientConfiguration';
-import createPoolConfiguration from './createPoolConfiguration';
+import {
+  createClientConfiguration,
+} from './createClientConfiguration';
+import {
+  createPoolConfiguration,
+} from './createPoolConfiguration';
 
 /**
  * @param connectionUri PostgreSQL [Connection URI](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING).
  */
-export default (
+export const createPool = (
   connectionUri: string,
   clientConfigurationInput?: ClientConfigurationInputType,
 ): DatabasePoolType => {

--- a/src/factories/createPoolConfiguration.ts
+++ b/src/factories/createPoolConfiguration.ts
@@ -6,12 +6,14 @@ import {
   ConnectionOptions,
   parse as parseConnectionString,
 } from 'pg-connection-string';
-import log from '../Logger';
+import {
+  Logger as log,
+} from '../Logger';
 import type {
   ClientConfigurationType,
 } from '../types';
 
-export default (connectionUri: string, clientConfiguration: ClientConfigurationType) => {
+export const createPoolConfiguration = (connectionUri: string, clientConfiguration: ClientConfigurationType) => {
   // @todo: make this not any. A few properties which don't exist on the interface are being set below
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const poolConfiguration: any = parseConnectionString(connectionUri);

--- a/src/factories/createPrimitiveValueExpressions.ts
+++ b/src/factories/createPrimitiveValueExpressions.ts
@@ -1,6 +1,8 @@
 // @flow
 
-import Logger from '../Logger';
+import {
+  Logger,
+} from '../Logger';
 import {
   UnexpectedStateError,
 } from '../errors';
@@ -12,7 +14,7 @@ const log = Logger.child({
   namespace: 'createPrimitiveValueExpressions',
 });
 
-export default (values: ReadonlyArray<unknown>): ReadonlyArray<PrimitiveValueExpressionType> => {
+export const createPrimitiveValueExpressions = (values: ReadonlyArray<unknown>): ReadonlyArray<PrimitiveValueExpressionType> => {
   const primitiveValueExpressions = [];
 
   for (const value of values) {

--- a/src/factories/createSqlTag.ts
+++ b/src/factories/createSqlTag.ts
@@ -1,6 +1,8 @@
 // @flow
 
-import Logger from '../Logger';
+import {
+  Logger,
+} from '../Logger';
 import {
   InvalidInputError,
 } from '../errors';
@@ -33,13 +35,15 @@ import {
   isPrimitiveValueExpression,
   isSqlToken,
 } from '../utilities';
-import createSqlTokenSqlFragment from './createSqlTokenSqlFragment';
+import {
+  createSqlTokenSqlFragment,
+} from './createSqlTokenSqlFragment';
 
 const log = Logger.child({
   namespace: 'sql',
 });
 
-export default <T = QueryResultRowType>() => {
+export const createSqlTag = <T = QueryResultRowType>() => {
   /* eslint-disable complexity */
   // @ts-ignore
   const sql: SqlTaggedTemplateType<T> = (

--- a/src/factories/createSqlTokenSqlFragment.ts
+++ b/src/factories/createSqlTokenSqlFragment.ts
@@ -26,7 +26,7 @@ import type {
   SqlFragmentType,
 } from '../types';
 
-export default (token: SqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
+export const createSqlTokenSqlFragment = (token: SqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
   if (token.type === ArrayToken) {
     return createArraySqlFragment(token, greatestParameterPosition);
   } else if (token.type === BinaryToken) {

--- a/src/factories/createTypeParserPreset.ts
+++ b/src/factories/createTypeParserPreset.ts
@@ -12,7 +12,7 @@ import {
   createTimestampWithTimeZoneTypeParser,
 } from './typeParsers';
 
-export default (): ReadonlyArray<TypeParserType> => {
+export const createTypeParserPreset = (): ReadonlyArray<TypeParserType> => {
   return [
     createBigintTypeParser(),
     createDateTypeParser(),

--- a/src/factories/index.ts
+++ b/src/factories/index.ts
@@ -1,26 +1,26 @@
 // @flow
 
 export {
-  default as createConnection,
+  createConnection,
 } from './createConnection';
 export {
-  default as createMockPool,
+  createMockPool,
 } from './createMockPool';
 export {
-  default as createMockQueryResult,
+  createMockQueryResult,
 } from './createMockQueryResult';
 export {
-  default as createPool,
+  createPool,
 } from './createPool';
 export {
-  default as createPrimitiveValueExpressions,
+  createPrimitiveValueExpressions,
 } from './createPrimitiveValueExpressions';
 export {
-  default as createSqlTag,
+  createSqlTag,
 } from './createSqlTag';
 export {
-  default as createSqlTokenSqlFragment,
+  createSqlTokenSqlFragment,
 } from './createSqlTokenSqlFragment';
 export {
-  default as createTypeParserPreset,
+  createTypeParserPreset,
 } from './createTypeParserPreset';

--- a/src/factories/typeParsers/createBigintTypeParser.ts
+++ b/src/factories/typeParsers/createBigintTypeParser.ts
@@ -9,7 +9,7 @@ const bigintParser = (value: string) => {
   return Number.parseInt(value, 10);
 };
 
-export default (): TypeParserType => {
+export const createBigintTypeParser = (): TypeParserType => {
   return {
     name: 'int8',
     parse: bigintParser,

--- a/src/factories/typeParsers/createDateTypeParser.ts
+++ b/src/factories/typeParsers/createDateTypeParser.ts
@@ -8,7 +8,7 @@ const dateParser = (value: string) => {
   return value;
 };
 
-export default (): TypeParserType => {
+export const createDateTypeParser = (): TypeParserType => {
   return {
     name: 'date',
     parse: dateParser,

--- a/src/factories/typeParsers/createIntervalTypeParser.ts
+++ b/src/factories/typeParsers/createIntervalTypeParser.ts
@@ -13,7 +13,7 @@ const intervalParser = (value: string) => {
   return value === null ? value : durationToSeconds(parseIsoDuration(parseInterval(value).toISOString()));
 };
 
-export default (): TypeParserType => {
+export const createIntervalTypeParser = (): TypeParserType => {
   return {
     name: 'interval',
     parse: intervalParser,

--- a/src/factories/typeParsers/createNumericTypeParser.ts
+++ b/src/factories/typeParsers/createNumericTypeParser.ts
@@ -8,7 +8,7 @@ const numericParser = (value: string) => {
   return Number.parseFloat(value);
 };
 
-export default (): TypeParserType => {
+export const createNumericTypeParser = (): TypeParserType => {
   return {
     name: 'numeric',
     parse: numericParser,

--- a/src/factories/typeParsers/createTimestampTypeParser.ts
+++ b/src/factories/typeParsers/createTimestampTypeParser.ts
@@ -8,7 +8,7 @@ const timestampParser = (value: string | null) => {
   return value === null ? value : Date.parse(value);
 };
 
-export default (): TypeParserType => {
+export const createTimestampTypeParser = (): TypeParserType => {
   return {
     name: 'timestamp',
     parse: timestampParser,

--- a/src/factories/typeParsers/createTimestampWithTimeZoneTypeParser.ts
+++ b/src/factories/typeParsers/createTimestampWithTimeZoneTypeParser.ts
@@ -8,7 +8,7 @@ const timestampParser = (value: string | null) => {
   return value === null ? value : Date.parse(value);
 };
 
-export default (): TypeParserType => {
+export const createTimestampWithTimeZoneTypeParser = (): TypeParserType => {
   return {
     name: 'timestamptz',
     parse: timestampParser,

--- a/src/factories/typeParsers/index.ts
+++ b/src/factories/typeParsers/index.ts
@@ -1,20 +1,20 @@
 // @flow
 
 export {
-  default as createBigintTypeParser,
+  createBigintTypeParser,
 } from './createBigintTypeParser';
 export {
-  default as createDateTypeParser,
+  createDateTypeParser,
 } from './createDateTypeParser';
 export {
-  default as createIntervalTypeParser,
+  createIntervalTypeParser,
 } from './createIntervalTypeParser';
 export {
-  default as createNumericTypeParser,
+  createNumericTypeParser,
 } from './createNumericTypeParser';
 export {
-  default as createTimestampTypeParser,
+  createTimestampTypeParser,
 } from './createTimestampTypeParser';
 export {
-  default as createTimestampWithTimeZoneTypeParser,
+  createTimestampWithTimeZoneTypeParser,
 } from './createTimestampWithTimeZoneTypeParser';

--- a/src/routines/createTypeOverrides.ts
+++ b/src/routines/createTypeOverrides.ts
@@ -10,7 +10,7 @@ import type {
 } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default async (connection: InternalDatabaseConnectionType, typeParsers: ReadonlyArray<TypeParserType>): Promise<any> => {
+export const createTypeOverrides = async (connection: InternalDatabaseConnectionType, typeParsers: ReadonlyArray<TypeParserType>): Promise<any> => {
   const typeOverrides = new TypeOverrides();
 
   if (typeParsers.length === 0) {

--- a/src/routines/executeQuery.ts
+++ b/src/routines/executeQuery.ts
@@ -109,7 +109,7 @@ const retryTransaction = async (
 };
 
 // eslint-disable-next-line complexity
-export default async (
+export const executeQuery = async (
   connectionLogger: LoggerType,
   connection: InternalDatabaseConnectionType,
   clientConfiguration: ClientConfigurationType,

--- a/src/routines/index.ts
+++ b/src/routines/index.ts
@@ -1,8 +1,8 @@
 // @flow
 
 export {
-  default as executeQuery,
+  executeQuery,
 } from './executeQuery';
 export {
-  default as createTypeOverrides,
+  createTypeOverrides,
 } from './createTypeOverrides';

--- a/src/sqlFragmentFactories/createArraySqlFragment.ts
+++ b/src/sqlFragmentFactories/createArraySqlFragment.ts
@@ -16,7 +16,7 @@ import {
   isSqlToken,
 } from '../utilities';
 
-export default (token: ArraySqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
+export const createArraySqlFragment = (token: ArraySqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
   let placeholderIndex = greatestParameterPosition;
 
   for (const value of token.values) {

--- a/src/sqlFragmentFactories/createBinarySqlFragment.ts
+++ b/src/sqlFragmentFactories/createBinarySqlFragment.ts
@@ -8,7 +8,7 @@ import type {
   SqlFragmentType,
 } from '../types';
 
-export default (token: BinarySqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
+export const createBinarySqlFragment = (token: BinarySqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
   if (!Buffer.isBuffer(token.data)) {
     throw new InvalidInputError('Binary value must be a buffer.');
   }

--- a/src/sqlFragmentFactories/createIdentifierSqlFragment.ts
+++ b/src/sqlFragmentFactories/createIdentifierSqlFragment.ts
@@ -11,7 +11,7 @@ import {
   escapeIdentifier,
 } from '../utilities';
 
-export default (token: IdentifierSqlTokenType): SqlFragmentType => {
+export const createIdentifierSqlFragment = (token: IdentifierSqlTokenType): SqlFragmentType => {
   const sql = token.names
     .map((identifierName) => {
       if (typeof identifierName !== 'string') {

--- a/src/sqlFragmentFactories/createJsonSqlFragment.ts
+++ b/src/sqlFragmentFactories/createJsonSqlFragment.ts
@@ -6,7 +6,9 @@ import {
 import {
   serializeError,
 } from 'serialize-error';
-import Logger from '../Logger';
+import {
+  Logger,
+} from '../Logger';
 import {
   InvalidInputError,
 } from '../errors';
@@ -19,7 +21,7 @@ const log = Logger.child({
   namespace: 'createJsonSqlFragment',
 });
 
-export default (token: JsonSqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
+export const createJsonSqlFragment = (token: JsonSqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
   let value;
 
   if (token.value === undefined) {

--- a/src/sqlFragmentFactories/createListSqlFragment.ts
+++ b/src/sqlFragmentFactories/createListSqlFragment.ts
@@ -16,7 +16,7 @@ import {
   isSqlToken,
 } from '../utilities';
 
-export default (token: ListSqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
+export const createListSqlFragment = (token: ListSqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
   const values = [];
   const placeholders = [];
 

--- a/src/sqlFragmentFactories/createSqlSqlFragment.ts
+++ b/src/sqlFragmentFactories/createSqlSqlFragment.ts
@@ -8,7 +8,7 @@ import type {
   SqlFragmentType,
 } from '../types';
 
-export default (token: SqlSqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
+export const createSqlSqlFragment = (token: SqlSqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
   let sql = '';
 
   let leastMatchedParameterPosition = Infinity;

--- a/src/sqlFragmentFactories/createUnnestSqlFragment.ts
+++ b/src/sqlFragmentFactories/createUnnestSqlFragment.ts
@@ -14,7 +14,7 @@ import {
   stripArrayNotation,
 } from '../utilities';
 
-export default (token: UnnestSqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
+export const createUnnestSqlFragment = (token: UnnestSqlTokenType, greatestParameterPosition: number): SqlFragmentType => {
   const columnTypes = token.columnTypes;
 
   const values = [];

--- a/src/sqlFragmentFactories/index.ts
+++ b/src/sqlFragmentFactories/index.ts
@@ -1,23 +1,23 @@
 // @flow
 
 export {
-  default as createArraySqlFragment,
+  createArraySqlFragment,
 } from './createArraySqlFragment';
 export {
-  default as createBinarySqlFragment,
+  createBinarySqlFragment,
 } from './createBinarySqlFragment';
 export {
-  default as createIdentifierSqlFragment,
+  createIdentifierSqlFragment,
 } from './createIdentifierSqlFragment';
 export {
-  default as createJsonSqlFragment,
+  createJsonSqlFragment,
 } from './createJsonSqlFragment';
 export {
-  default as createListSqlFragment,
+  createListSqlFragment,
 } from './createListSqlFragment';
 export {
-  default as createSqlSqlFragment,
+  createSqlSqlFragment,
 } from './createSqlSqlFragment';
 export {
-  default as createUnnestSqlFragment,
+  createUnnestSqlFragment,
 } from './createUnnestSqlFragment';

--- a/src/utilities/countArrayDimensions.ts
+++ b/src/utilities/countArrayDimensions.ts
@@ -1,6 +1,6 @@
 // @flow
 
-export default (identifierName: string): number => {
+export const countArrayDimensions = (identifierName: string): number => {
   let tail = identifierName.trim();
   let arrayDimensionCount = 0;
 

--- a/src/utilities/createQueryId.ts
+++ b/src/utilities/createQueryId.ts
@@ -3,9 +3,11 @@
 import type {
   QueryIdType,
 } from '../types';
-import createUlid from './createUlid';
+import {
+  createUlid,
+} from './createUlid';
 
-export default (): QueryIdType => {
+export const createQueryId = (): QueryIdType => {
   // eslint-disable-next-line no-extra-parens, @typescript-eslint/no-explicit-any
   return createUlid() as any;
 };

--- a/src/utilities/createUlid.ts
+++ b/src/utilities/createUlid.ts
@@ -7,6 +7,6 @@ import {
 
 const ulid = ulidFactory(detectPrng(true));
 
-export default (): string => {
+export const createUlid = (): string => {
   return ulid();
 };

--- a/src/utilities/deepFreeze.ts
+++ b/src/utilities/deepFreeze.ts
@@ -15,7 +15,7 @@ const isSubjectFreezable = (subject: any): boolean => {
  * @see https://github.com/substack/deep-freeze/pull/9
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const deepFreeze = (subject: any) => {
+export const deepFreeze = (subject: any) => {
   if (!isSubjectFreezable(subject)) {
     return subject;
   }
@@ -30,5 +30,3 @@ const deepFreeze = (subject: any) => {
 
   return subject;
 };
-
-export default deepFreeze;

--- a/src/utilities/encodeTupleList.ts
+++ b/src/utilities/encodeTupleList.ts
@@ -11,7 +11,7 @@ import type {
   TypeNameIdentifierType,
 } from '../types';
 
-export default (
+export const encodeTupleList = (
   tupleList: ReadonlyArray<ReadonlyArray<unknown>>,
   columnTypes: ReadonlyArray<TypeNameIdentifierType>,
 ): Promise<Buffer> => {

--- a/src/utilities/escapeIdentifier.ts
+++ b/src/utilities/escapeIdentifier.ts
@@ -3,6 +3,6 @@
 /**
  * @see https://github.com/brianc/node-postgres/blob/6c840aabb09f8a2d640800953f6b884b6841384c/lib/client.js#L306-L322
  */
-export default (identifier: string) => {
+export const escapeIdentifier = (identifier: string) => {
   return '"' + identifier.replace(/"/g, '""') + '"';
 };

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,35 +1,35 @@
 // @flow
 
 export {
-  default as countArrayDimensions,
+  countArrayDimensions,
 } from './countArrayDimensions';
 export {
-  default as createQueryId,
+  createQueryId,
 } from './createQueryId';
 export {
-  default as createUlid,
+  createUlid,
 } from './createUlid';
 export {
-  default as deepFreeze,
+  deepFreeze,
 } from './deepFreeze';
 export {
-  default as encodeTupleList,
+  encodeTupleList,
 } from './encodeTupleList';
 export {
-  default as escapeIdentifier,
+  escapeIdentifier,
 } from './escapeIdentifier';
 export {
-  default as isPrimitiveValueExpression,
+  isPrimitiveValueExpression,
 } from './isPrimitiveValueExpression';
 export {
-  default as isSqlToken,
+  isSqlToken,
 } from './isSqlToken';
 export {
-  default as mapTaggedTemplateLiteralInvocation,
+  mapTaggedTemplateLiteralInvocation,
 } from './mapTaggedTemplateLiteralInvocation';
 export {
-  default as normaliseQueryValues,
+  normaliseQueryValues,
 } from './normaliseQueryValues';
 export {
-  default as stripArrayNotation,
+  stripArrayNotation,
 } from './stripArrayNotation';

--- a/src/utilities/isPrimitiveValueExpression.ts
+++ b/src/utilities/isPrimitiveValueExpression.ts
@@ -1,5 +1,5 @@
 // @flow
 
-export default (maybe: unknown): maybe is string | number | boolean | null => {
+export const isPrimitiveValueExpression = (maybe: unknown): maybe is string | number | boolean | null => {
   return typeof maybe === 'string' || typeof maybe === 'number' || typeof maybe === 'boolean' || maybe === null;
 };

--- a/src/utilities/isSqlToken.ts
+++ b/src/utilities/isSqlToken.ts
@@ -23,7 +23,7 @@ const Tokens = [
 ] as const;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default (subject: any): subject is typeof Tokens[number] => {
+export const isSqlToken = (subject: any): subject is typeof Tokens[number] => {
   if (typeof subject !== 'object' || subject === null) {
     return false;
   }

--- a/src/utilities/mapTaggedTemplateLiteralInvocation.ts
+++ b/src/utilities/mapTaggedTemplateLiteralInvocation.ts
@@ -9,7 +9,7 @@ import {
 } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default (targetMethod: (sql: string, values: readonly PrimitiveValueExpressionType[]) => any) => {
+export const mapTaggedTemplateLiteralInvocation = (targetMethod: (sql: string, values: readonly PrimitiveValueExpressionType[]) => any) => {
   return <T>(query: TaggedTemplateLiteralInvocationType<T>) => {
     if (query.type !== SqlToken) {
       throw new TypeError('Query must be constructed using `sql` tagged template literal.');

--- a/src/utilities/normaliseQueryValues.ts
+++ b/src/utilities/normaliseQueryValues.ts
@@ -4,7 +4,10 @@ import type {
   PrimitiveValueExpressionType,
 } from '../types';
 
-export default (queryValues: ReadonlyArray<PrimitiveValueExpressionType>, native: boolean): ReadonlyArray<PrimitiveValueExpressionType> => {
+export const normaliseQueryValues = (
+  queryValues: ReadonlyArray<PrimitiveValueExpressionType>,
+  native: boolean,
+): ReadonlyArray<PrimitiveValueExpressionType> => {
   if (native && queryValues) {
     const finalValues = [];
 

--- a/src/utilities/stripArrayNotation.ts
+++ b/src/utilities/stripArrayNotation.ts
@@ -1,6 +1,6 @@
 // @flow
 
-export default (identifierName: string): string => {
+export const stripArrayNotation = (identifierName: string): string => {
   let tail = identifierName.trim();
 
   while (tail.endsWith('[]')) {

--- a/test/helpers/Logger.ts
+++ b/test/helpers/Logger.ts
@@ -1,8 +1,8 @@
 // @flow
 
-import Logger from 'roarr';
+import roarr from 'roarr';
 
-export default Logger.child({
+export const Logger = roarr.child({
   connectionId: '1',
   poolId: '1',
 });

--- a/test/helpers/createClientConfiguration.ts
+++ b/test/helpers/createClientConfiguration.ts
@@ -4,7 +4,7 @@ import type {
   ClientConfigurationType,
 } from '../../src/types';
 
-export default (): ClientConfigurationType => {
+export const createClientConfiguration = (): ClientConfigurationType => {
   return {
     captureStackTrace: true,
     connectionRetryLimit: 3,

--- a/test/helpers/createConnectionContext.ts
+++ b/test/helpers/createConnectionContext.ts
@@ -4,7 +4,7 @@ import type {
   ConnectionContextType,
 } from '../../src/types';
 
-export default (): ConnectionContextType => {
+export const createConnectionContext = (): ConnectionContextType => {
   // @ts-ignore
   return {
     connectionId: '1',

--- a/test/helpers/createPool.ts
+++ b/test/helpers/createPool.ts
@@ -4,18 +4,22 @@
 
 import EventEmitter from 'events';
 import sinon from 'sinon';
-import bindPool from '../../src/binders/bindPool';
+import {
+  bindPool,
+} from '../../src/binders/bindPool';
 import type {
   ClientConfigurationInputType,
 } from '../../src/types';
-import log from './Logger';
+import {
+  Logger as log,
+} from './Logger';
 
 const defaultConfiguration = {
   interceptors: [],
   typeParsers: [],
 };
 
-export default (clientConfiguration: ClientConfigurationInputType = defaultConfiguration) => {
+export const createPool = (clientConfiguration: ClientConfigurationInputType = defaultConfiguration) => {
   // @ts-expect-error
   const eventEmitter = new EventEmitter();
 

--- a/test/helpers/createQueryContext.ts
+++ b/test/helpers/createQueryContext.ts
@@ -4,7 +4,7 @@ import type {
   QueryContextType,
 } from '../../src/types';
 
-export default (): QueryContextType => {
+export const createQueryContext = (): QueryContextType => {
   // @ts-ignore
   return {
     connectionId: '1',

--- a/test/slonik/binders/bindPool/connect.ts
+++ b/test/slonik/binders/bindPool/connect.ts
@@ -2,8 +2,12 @@
 // @flow
 
 import test from 'ava';
-import createSqlTag from '../../../../src/factories/createSqlTag';
-import createPool from '../../../helpers/createPool';
+import {
+  createSqlTag,
+} from '../../../../src/factories/createSqlTag';
+import {
+  createPool,
+} from '../../../helpers/createPool';
 
 const sql = createSqlTag();
 

--- a/test/slonik/binders/bindPool/interceptors/afterPoolConnection.ts
+++ b/test/slonik/binders/bindPool/interceptors/afterPoolConnection.ts
@@ -2,8 +2,12 @@
 
 import test from 'ava';
 import sinon from 'sinon';
-import createSqlTag from '../../../../../src/factories/createSqlTag';
-import createPool from '../../../../helpers/createPool';
+import {
+  createSqlTag,
+} from '../../../../../src/factories/createSqlTag';
+import {
+  createPool,
+} from '../../../../helpers/createPool';
 
 const sql = createSqlTag();
 

--- a/test/slonik/binders/bindPool/interceptors/beforePoolConnection.ts
+++ b/test/slonik/binders/bindPool/interceptors/beforePoolConnection.ts
@@ -2,7 +2,9 @@
 
 import test from 'ava';
 import sinon from 'sinon';
-import createPool from '../../../../helpers/createPool';
+import {
+  createPool,
+} from '../../../../helpers/createPool';
 
 test('`beforePoolConnection` is called before `connect`', async (t) => {
   const beforePoolConnection = sinon.stub();

--- a/test/slonik/binders/bindPool/transaction.ts
+++ b/test/slonik/binders/bindPool/transaction.ts
@@ -2,8 +2,12 @@
 
 import test from 'ava';
 import delay from 'delay';
-import createSqlTag from '../../../../src/factories/createSqlTag';
-import createPool from '../../../helpers/createPool';
+import {
+  createSqlTag,
+} from '../../../../src/factories/createSqlTag';
+import {
+  createPool,
+} from '../../../helpers/createPool';
 
 const sql = createSqlTag();
 

--- a/test/slonik/connectionMethods/anyFirst.ts
+++ b/test/slonik/connectionMethods/anyFirst.ts
@@ -4,8 +4,12 @@ import test from 'ava';
 import {
   DataIntegrityError,
 } from '../../../src/errors';
-import createSqlTag from '../../../src/factories/createSqlTag';
-import createPool from '../../helpers/createPool';
+import {
+  createSqlTag,
+} from '../../../src/factories/createSqlTag';
+import {
+  createPool,
+} from '../../helpers/createPool';
 
 const sql = createSqlTag();
 

--- a/test/slonik/connectionMethods/many.ts
+++ b/test/slonik/connectionMethods/many.ts
@@ -4,8 +4,12 @@ import test from 'ava';
 import {
   NotFoundError,
 } from '../../../src/errors';
-import createSqlTag from '../../../src/factories/createSqlTag';
-import createPool from '../../helpers/createPool';
+import {
+  createSqlTag,
+} from '../../../src/factories/createSqlTag';
+import {
+  createPool,
+} from '../../helpers/createPool';
 
 const sql = createSqlTag();
 

--- a/test/slonik/connectionMethods/manyFirst.ts
+++ b/test/slonik/connectionMethods/manyFirst.ts
@@ -7,8 +7,12 @@ import {
   DataIntegrityError,
   NotFoundError,
 } from '../../../src/errors';
-import createSqlTag from '../../../src/factories/createSqlTag';
-import createPool from '../../helpers/createPool';
+import {
+  createSqlTag,
+} from '../../../src/factories/createSqlTag';
+import {
+  createPool,
+} from '../../helpers/createPool';
 
 const sql = createSqlTag();
 

--- a/test/slonik/connectionMethods/maybeOne.ts
+++ b/test/slonik/connectionMethods/maybeOne.ts
@@ -4,8 +4,12 @@ import test from 'ava';
 import {
   DataIntegrityError,
 } from '../../../src/errors';
-import createSqlTag from '../../../src/factories/createSqlTag';
-import createPool from '../../helpers/createPool';
+import {
+  createSqlTag,
+} from '../../../src/factories/createSqlTag';
+import {
+  createPool,
+} from '../../helpers/createPool';
 
 const sql = createSqlTag();
 

--- a/test/slonik/connectionMethods/maybeOneFirst.ts
+++ b/test/slonik/connectionMethods/maybeOneFirst.ts
@@ -4,8 +4,12 @@ import test from 'ava';
 import {
   DataIntegrityError,
 } from '../../../src/errors';
-import createSqlTag from '../../../src/factories/createSqlTag';
-import createPool from '../../helpers/createPool';
+import {
+  createSqlTag,
+} from '../../../src/factories/createSqlTag';
+import {
+  createPool,
+} from '../../helpers/createPool';
 
 const sql = createSqlTag();
 

--- a/test/slonik/connectionMethods/one.ts
+++ b/test/slonik/connectionMethods/one.ts
@@ -5,8 +5,12 @@ import {
   DataIntegrityError,
   NotFoundError,
 } from '../../../src/errors';
-import createSqlTag from '../../../src/factories/createSqlTag';
-import createPool from '../../helpers/createPool';
+import {
+  createSqlTag,
+} from '../../../src/factories/createSqlTag';
+import {
+  createPool,
+} from '../../helpers/createPool';
 
 const sql = createSqlTag();
 

--- a/test/slonik/connectionMethods/oneFirst.ts
+++ b/test/slonik/connectionMethods/oneFirst.ts
@@ -6,8 +6,12 @@ import {
   NotFoundError,
   UnexpectedStateError,
 } from '../../../src/errors';
-import createSqlTag from '../../../src/factories/createSqlTag';
-import createPool from '../../helpers/createPool';
+import {
+  createSqlTag,
+} from '../../../src/factories/createSqlTag';
+import {
+  createPool,
+} from '../../helpers/createPool';
 
 const sql = createSqlTag();
 

--- a/test/slonik/connectionMethods/query/interceptors/beforeQueryExecution.ts
+++ b/test/slonik/connectionMethods/query/interceptors/beforeQueryExecution.ts
@@ -1,8 +1,12 @@
 // @flow
 
 import test from 'ava';
-import createSqlTag from '../../../../../src/factories/createSqlTag';
-import createPool from '../../../../helpers/createPool';
+import {
+  createSqlTag,
+} from '../../../../../src/factories/createSqlTag';
+import {
+  createPool,
+} from '../../../../helpers/createPool';
 
 const sql = createSqlTag();
 

--- a/test/slonik/connectionMethods/query/interceptors/transformQuery.ts
+++ b/test/slonik/connectionMethods/query/interceptors/transformQuery.ts
@@ -1,8 +1,12 @@
 // @flow
 
 import test from 'ava';
-import createSqlTag from '../../../../../src/factories/createSqlTag';
-import createPool from '../../../../helpers/createPool';
+import {
+  createSqlTag,
+} from '../../../../../src/factories/createSqlTag';
+import {
+  createPool,
+} from '../../../../helpers/createPool';
 
 const sql = createSqlTag();
 

--- a/test/slonik/connectionMethods/query/interceptors/transformRow.ts
+++ b/test/slonik/connectionMethods/query/interceptors/transformRow.ts
@@ -1,8 +1,12 @@
 // @flow
 
 import test from 'ava';
-import createSqlTag from '../../../../../src/factories/createSqlTag';
-import createPool from '../../../../helpers/createPool';
+import {
+  createSqlTag,
+} from '../../../../../src/factories/createSqlTag';
+import {
+  createPool,
+} from '../../../../helpers/createPool';
 
 const sql = createSqlTag();
 

--- a/test/slonik/connectionMethods/query/query.ts
+++ b/test/slonik/connectionMethods/query/query.ts
@@ -10,8 +10,12 @@ import {
   NotNullIntegrityConstraintViolationError,
   UniqueIntegrityConstraintViolationError,
 } from '../../../../src/errors';
-import createSqlTag from '../../../../src/factories/createSqlTag';
-import createPool from '../../../helpers/createPool';
+import {
+  createSqlTag,
+} from '../../../../src/factories/createSqlTag';
+import {
+  createPool,
+} from '../../../helpers/createPool';
 
 const sql = createSqlTag();
 

--- a/test/slonik/connectionMethods/transaction.ts
+++ b/test/slonik/connectionMethods/transaction.ts
@@ -1,7 +1,9 @@
 // @flow
 
 import test from 'ava';
-import createPool from '../../helpers/createPool';
+import {
+  createPool,
+} from '../../helpers/createPool';
 
 test('commits successful transaction', async (t) => {
   const pool = createPool();

--- a/test/slonik/factories/createClientConfiguration.ts
+++ b/test/slonik/factories/createClientConfiguration.ts
@@ -1,8 +1,12 @@
 // @flow
 
 import test from 'ava';
-import createClientConfiguration from '../../../src/factories/createClientConfiguration';
-import createTypeParserPreset from '../../../src/factories/createTypeParserPreset';
+import {
+  createClientConfiguration,
+} from '../../../src/factories/createClientConfiguration';
+import {
+  createTypeParserPreset,
+} from '../../../src/factories/createTypeParserPreset';
 
 const defaultConfiguration = {
   captureStackTrace: true,

--- a/test/slonik/factories/createMockPool.ts
+++ b/test/slonik/factories/createMockPool.ts
@@ -6,8 +6,12 @@ import {
   DataIntegrityError,
   sql,
 } from '../../../src';
-import createMockPool from '../../../src/factories/createMockPool';
-import createMockQueryResult from '../../../src/factories/createMockQueryResult';
+import {
+  createMockPool,
+} from '../../../src/factories/createMockPool';
+import {
+  createMockQueryResult,
+} from '../../../src/factories/createMockQueryResult';
 
 test('executes a mock query (pool.query)', async (t) => {
   t.plan(4);

--- a/test/slonik/routines/createTypeOverrides.ts
+++ b/test/slonik/routines/createTypeOverrides.ts
@@ -1,7 +1,9 @@
 // @flow
 
 import test from 'ava';
-import createTypeOverrides from '../../../src/routines/createTypeOverrides';
+import {
+  createTypeOverrides,
+} from '../../../src/routines/createTypeOverrides';
 
 test('uses typname to retrieve pg_type oid', async (t) => {
   const connection = {

--- a/test/slonik/routines/executeQuery.ts
+++ b/test/slonik/routines/executeQuery.ts
@@ -9,8 +9,12 @@ import Roarr from 'roarr';
 import {
   InvalidInputError,
 } from '../../../src/errors';
-import executeQuery from '../../../src/routines/executeQuery';
-import createClientConfiguration from '../../helpers/createClientConfiguration';
+import {
+  executeQuery,
+} from '../../../src/routines/executeQuery';
+import {
+  createClientConfiguration,
+} from '../../helpers/createClientConfiguration';
 
 const test = anyTest as TestInterface<any>;
 const beforeEach = anyBeforeEach as BeforeInterface<any>;

--- a/test/slonik/templateTags/sql/array.ts
+++ b/test/slonik/templateTags/sql/array.ts
@@ -1,7 +1,9 @@
 // @flow
 
 import test from 'ava';
-import createSqlTag from '../../../../src/factories/createSqlTag';
+import {
+  createSqlTag,
+} from '../../../../src/factories/createSqlTag';
 import {
   SqlToken,
 } from '../../../../src/tokens';

--- a/test/slonik/templateTags/sql/identifier.ts
+++ b/test/slonik/templateTags/sql/identifier.ts
@@ -1,7 +1,9 @@
 // @flow
 
 import test from 'ava';
-import createSqlTag from '../../../../src/factories/createSqlTag';
+import {
+  createSqlTag,
+} from '../../../../src/factories/createSqlTag';
 import {
   SqlToken,
 } from '../../../../src/tokens';

--- a/test/slonik/templateTags/sql/join.ts
+++ b/test/slonik/templateTags/sql/join.ts
@@ -1,7 +1,9 @@
 // @flow
 
 import test from 'ava';
-import createSqlTag from '../../../../src/factories/createSqlTag';
+import {
+  createSqlTag,
+} from '../../../../src/factories/createSqlTag';
 import {
   SqlToken,
 } from '../../../../src/tokens';

--- a/test/slonik/templateTags/sql/json.ts
+++ b/test/slonik/templateTags/sql/json.ts
@@ -1,7 +1,9 @@
 // @flow
 
 import test from 'ava';
-import createSqlTag from '../../../../src/factories/createSqlTag';
+import {
+  createSqlTag,
+} from '../../../../src/factories/createSqlTag';
 import {
   SqlToken,
 } from '../../../../src/tokens';

--- a/test/slonik/templateTags/sql/sql.ts
+++ b/test/slonik/templateTags/sql/sql.ts
@@ -1,7 +1,9 @@
 // @flow
 
 import test from 'ava';
-import createSqlTag from '../../../../src/factories/createSqlTag';
+import {
+  createSqlTag,
+} from '../../../../src/factories/createSqlTag';
 import {
   SqlToken,
 } from '../../../../src/tokens';

--- a/test/slonik/templateTags/sql/unnest.ts
+++ b/test/slonik/templateTags/sql/unnest.ts
@@ -1,7 +1,9 @@
 // @flow
 
 import test from 'ava';
-import createSqlTag from '../../../../src/factories/createSqlTag';
+import {
+  createSqlTag,
+} from '../../../../src/factories/createSqlTag';
 import {
   SqlToken,
 } from '../../../../src/tokens';

--- a/test/slonik/utilities/countArrayDimensions.ts
+++ b/test/slonik/utilities/countArrayDimensions.ts
@@ -1,7 +1,9 @@
 // @flow
 
 import test from 'ava';
-import countArrayDimensions from '../../../src/utilities/countArrayDimensions';
+import {
+  countArrayDimensions,
+} from '../../../src/utilities/countArrayDimensions';
 
 test('returns the number of array dimensions', (t) => {
   t.assert(countArrayDimensions('foo') === 0);

--- a/test/slonik/utilities/deepFreeze.ts
+++ b/test/slonik/utilities/deepFreeze.ts
@@ -1,7 +1,9 @@
 // @flow
 
 import test from 'ava';
-import deepFreeze from '../../../src/utilities/deepFreeze';
+import {
+  deepFreeze,
+} from '../../../src/utilities/deepFreeze';
 
 test('ignores primitives', (t) => {
   t.is(deepFreeze('foo'), 'foo');

--- a/test/slonik/utilities/mapTaggedTemplateLiteralInvocation.ts
+++ b/test/slonik/utilities/mapTaggedTemplateLiteralInvocation.ts
@@ -2,7 +2,9 @@
 
 import test from 'ava';
 import sinon from 'sinon';
-import createSqlTag from '../../../src/factories/createSqlTag';
+import {
+  createSqlTag,
+} from '../../../src/factories/createSqlTag';
 import {
   mapTaggedTemplateLiteralInvocation,
 } from '../../../src/utilities';
@@ -39,4 +41,3 @@ test('throws an error if invoked with a string', (t) => {
 
   t.is(error.message, 'Query must be constructed using `sql` tagged template literal.');
 });
-

--- a/test/slonik/utilities/stripArrayNotation.ts
+++ b/test/slonik/utilities/stripArrayNotation.ts
@@ -1,7 +1,9 @@
 // @flow
 
 import test from 'ava';
-import stripArrayNotation from '../../../src/utilities/stripArrayNotation';
+import {
+  stripArrayNotation,
+} from '../../../src/utilities/stripArrayNotation';
 
 test('strips array notation', (t) => {
   t.assert(stripArrayNotation('foo') === 'foo');

--- a/test/types.ts
+++ b/test/types.ts
@@ -10,7 +10,7 @@ import {
 } from '../src/types';
 
 // this is never actually run - it's purely a type-level "test" to ensure the typings don't regress.
-export default async () => {
+export const types = async () => {
   const client = createPool('');
 
   const query = await client.query(sql`select true`);


### PR DESCRIPTION
Related: #209 
Part of #195

Since switching from babel to typescript for building in #212, we can no longer use a plugin to give default-exported functions names as a transpilation step, which would make call stacks worse (default-exported functions appear anonymous). I used a dumb script to do the conversion, which probably would fall over for projects that weren't as consistent with naming conventions, etc.: https://gist.github.com/mmkal/e2d8434c9f7061a173bb32216af87a5a