### PR TITLE
fix: promote @types/roarr to a prod dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "timeout": "30s"
   },
   "dependencies": {
+    "@types/roarr": "^2.14.2",
     "concat-stream": "^2.0.0",
     "delay": "^4.4.0",
     "es6-error": "^4.1.1",
@@ -41,7 +42,6 @@
     "@types/concat-stream": "^1.6.0",
     "@types/pg": "^7.14.5",
     "@types/pg-copy-streams": "^1.2.1",
-    "@types/roarr": "^2.14.2",
     "@types/sinon": "^9.0.8",
     "@types/through2": "^2.0.36",
     "@typescript-eslint/eslint-plugin": "^4.5.0",


### PR DESCRIPTION
@gajus just tried v23 in a typescript project which happened not to have roarr types pre-installed. There's a build error because slonik re-exports a type from roarr's domain: 
https://github.com/gajus/slonik/blob/8f00e592186d3b751a04a4ed4c5fc2f7fbc47ecc/src/types.ts#L12-L14
https://github.com/gajus/slonik/blob/8f00e592186d3b751a04a4ed4c5fc2f7fbc47ecc/src/types.ts#L20-L22

That's fine, but it means that the roarr types are now a full dependency, not just dev, because downstream consumers now care about them. A peer dependency would also work but it's unnecessary inconvenient, and the types are very light, since they contain no runtime code.