### PR TITLE
fix(types): re-add 'uuid' as part of TypeNameIdentifierType

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,8 @@ export type TypeNameIdentifierType =
   | 'int4'
   | 'json'
   | 'text'
-  | 'timestamptz';
+  | 'timestamptz'
+  | 'uuid';
 
 export type SerializableValueType =
   | string


### PR DESCRIPTION
In Type definition from DefinitelyTyped/@types/slonik TypeNameIdentifierType included 'uuid' as an accepted type.
This was needed for writing queries like `sql.array([...], 'uuid')`

Re-added 'uuid' to TypeNameIdentifierType.

re #195, re DefinitelyTyped/DefinitelyTyped#42632, fix #135