### PR TITLE
fix: allow SerializableValueType to include Record types with optional fields (fixes #222)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
     "@typescript-eslint/no-non-null-assertion": 1,
     "@typescript-eslint/prefer-ts-expect-error": 1,
     "unicorn/prevent-abbreviations": 0,
+    "unicorn/numeric-separators-style": 0,
     "no-undef": 0,
     "linebreak-style": 0,
     // https://github.com/typescript-eslint/typescript-eslint/issues/1624#issuecomment-589731039

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export type SerializableValueType =
   | boolean
   | null
   | {
-      [key: string]: SerializableValueType;
+      [key: string]: SerializableValueType | undefined;
     }
   | ReadonlyArray<SerializableValueType>;
 

--- a/test/slonik/templateTags/sql/json.ts
+++ b/test/slonik/templateTags/sql/json.ts
@@ -122,3 +122,18 @@ test('the resulting object is immutable', (t) => {
     token.foo = 'bar';
   });
 });
+
+test('Object types with optional properties are allowed', (t) => {
+  type TypeWithOptionalProperty = { foo: string; opt?: string };
+  const testValue: TypeWithOptionalProperty = {foo: 'bar'};
+
+  const query = sql`SELECT ${sql.json(testValue)}`;
+
+  t.deepEqual(query, {
+    sql: 'SELECT $1',
+    type: SqlToken,
+    values: [
+      '{"foo":"bar"}',
+    ],
+  });
+});


### PR DESCRIPTION
Some notes:

1. I was getting lots of "Invalid group length in numeric value  unicorn/numeric-separators-style" eslint errors, which I thought was perhaps a recent addition to a base eslint dep? In any case I excluded this in the .eslintrc file.
2. The added test case will succeed even if SerializableValueType isn't modified BUT running `npm run type-check` would correctly fail so I think that is sufficient.