### PR TITLE
fix(types): export CommonQueryMethodsType

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export type {
   BinarySqlTokenType,
   ClientConfigurationInputType,
   ClientConfigurationType,
+  CommonQueryMethodsType,
   ConnectionTypeType,
   DatabaseConnectionType,
   DatabasePoolConnectionType,

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,7 +132,7 @@ export type QueryCopyFromBinaryFunctionType = (
   columnTypes: ReadonlyArray<TypeNameIdentifierType>,
 ) => Promise<null | object>; // bindPoolConnection returns an object
 
-type CommonQueryMethodsType = {
+export type CommonQueryMethodsType = {
   readonly any: QueryAnyFunctionType;
   readonly anyFirst: QueryAnyFirstFunctionType;
   readonly exists: QueryExistsFunctionType;

--- a/test/dts.ts
+++ b/test/dts.ts
@@ -408,3 +408,8 @@ const samplesFromDocs = async () => {
 
   // end samples from readme
 };
+
+const exportedTypes = () => {
+  // make sure CommonQueryMethodsType is exported by package
+  expectTypeOf<import('../src').CommonQueryMethodsType>().toHaveProperty('any').toBeCallableWith(sql`select 1`);
+};


### PR DESCRIPTION
This was exported in the separate type declarations, and it's a useful helper.

Fixes #217 