### PR TITLE
fix(types): export TypeNameIdentifierType

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export type {
   SqlTaggedTemplateType,
   SqlTokenType,
   TaggedTemplateLiteralInvocationType,
+  TypeNameIdentifierType,
   TypeParserType,
   UnnestSqlTokenType,
   ValueExpressionType,


### PR DESCRIPTION
Discovered after upgrading and a call to `sql.array()` was no longer possible without tricking the compiler with `... as unknown as SqlTokenType`