### PR TITLE
feat: expose pool configuration

### DIFF
--- a/src/binders/bindPool.ts
+++ b/src/binders/bindPool.ts
@@ -48,6 +48,7 @@ export const bindPool = (
   return {
     any: mapConnection('any'),
     anyFirst: mapConnection('anyFirst'),
+    configuration: clientConfiguration,
     connect: (connectionHandler) => {
       return createConnection(
         parentLog,

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,6 +173,7 @@ export type DatabasePoolType = CommonQueryMethodsType & {
   readonly getPoolState: () => PoolStateType;
   readonly stream: StreamFunctionType;
   readonly transaction: <T>(handler: TransactionFunctionType<T>) => Promise<T>;
+  readonly configuration: ClientConfigurationType;
 };
 
 /**

--- a/test/dts.ts
+++ b/test/dts.ts
@@ -30,6 +30,7 @@ import {
   createTypeParserPreset,
   sql,
   QueryResultType,
+  ClientConfigurationType,
 } from '../src';
 
 const VALUE = 'foo';
@@ -38,6 +39,8 @@ const connection = createPool('postgres://');
 
 const poolTypes = () => {
   const pool = createPool('postgres://localhost');
+
+  expectTypeOf(pool).toHaveProperty('configuration').toEqualTypeOf<ClientConfigurationType>();
 
   const promise = pool.connect(async (conn) => {
     const result = await conn.query(sql`SELECT 1`);

--- a/test/slonik/factories/createPool.ts
+++ b/test/slonik/factories/createPool.ts
@@ -1,0 +1,22 @@
+import test from 'ava';
+import {
+  createPool,
+} from '../../../src/factories/createPool';
+
+test('pools can be extended', (t) => {
+  const prodPool = createPool('', {
+    idleInTransactionSessionTimeout: 'DISABLE_TIMEOUT',
+    idleTimeout: 5000,
+  });
+
+  const testPool = createPool('', {
+    ...prodPool.configuration,
+    idleTimeout: 1000,
+  });
+
+  t.is(prodPool.configuration.idleInTransactionSessionTimeout, 'DISABLE_TIMEOUT');
+  t.is(testPool.configuration.idleInTransactionSessionTimeout, 'DISABLE_TIMEOUT');
+
+  t.is(prodPool.configuration.idleTimeout, 5000);
+  t.is(testPool.configuration.idleTimeout, 1000);
+});


### PR DESCRIPTION
Fixes #242 

@gajus you'd mentioned that we should only surface what's needed, and I did try that out, but I couldn't find a way that seemed right. Exposing only part of the resolved configuration feels dangerous to me, because it'd be easy to try to create a new pool with an old one's settings, and assume that important fields like `interceptors`, `idleTimeout` etc. were copied over.

Another way to think of it: it's only exposing _one_ field, `configuration`. Any breaking changes on `ClientConfigurationType` are already breaking since it's used as the input to `createPool`.