### PR TITLE
feat: allow .stream() on transaction binders (#252)

### DIFF
--- a/src/binders/bindTransactionConnection.ts
+++ b/src/binders/bindTransactionConnection.ts
@@ -12,6 +12,7 @@ import {
   nestedTransaction,
   one,
   oneFirst,
+  stream,
   query as queryMethod,
 } from '../connectionMethods';
 import type {
@@ -153,6 +154,19 @@ export const bindTransactionConnection = (
         clientConfiguration,
         query.sql,
         query.values,
+      );
+    },
+    stream: (query, streamHandler) => {
+      assertSqlSqlToken(query);
+      assertTransactionDepth();
+
+      return stream(
+        parentLog,
+        connection,
+        clientConfiguration,
+        query.sql,
+        query.values,
+        streamHandler,
       );
     },
     transaction: (handler) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,7 @@ export type CommonQueryMethodsType = {
 };
 
 export type DatabaseTransactionConnectionType = CommonQueryMethodsType & {
+  readonly stream: StreamFunctionType,
   readonly transaction: <T>(handler: TransactionFunctionType<T>) => Promise<T>,
 };
 


### PR DESCRIPTION
as discussed in #252. happy to make any other changes of course. and also happy to not include the test if it's frivolous.