### PR TITLE
feat(types): remove readonly from result types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ export type QueryResultType<T> = {
   readonly fields: readonly FieldType[],
   readonly notices: readonly NoticeType[],
   readonly rowCount: number,
-  readonly rows: readonly T[],
+  readonly rows: T[],
 };
 
 export type InternalDatabasePoolType = any;
@@ -83,7 +83,7 @@ export type ClientConfigurationType = {
   /** Timeout (in milliseconds) after which idle clients are closed. Use 'DISABLE_TIMEOUT' constant to disable the timeout. (Default: 5000) */
   readonly idleTimeout: number | 'DISABLE_TIMEOUT',
   /** An array of [Slonik interceptors](https://github.com/gajus/slonik#slonik-interceptors). */
-  readonly interceptors: readonly InterceptorType[],
+  readonly interceptors: InterceptorType[],
   /** Do not allow more than this many connections. Use 'DISABLE_TIMEOUT' constant to disable the timeout. (Default: 10) */
   readonly maximumPoolSize: number,
   /** Uses libpq bindings when `pg-native` module is installed. (Default: true) */
@@ -93,7 +93,7 @@ export type ClientConfigurationType = {
   /** Number of times a transaction failing with Transaction Rollback class error is retried. (Default: 5) */
   readonly transactionRetryLimit: number,
   /** An array of [Slonik type parsers](https://github.com/gajus/slonik#slonik-type-parsers). */
-  readonly typeParsers: readonly TypeParserType[],
+  readonly typeParsers: TypeParserType[],
 };
 
 export type ClientConfigurationInputType = Partial<ClientConfigurationType>;
@@ -105,8 +105,8 @@ export type StreamFunctionType = (
 
 export type QueryCopyFromBinaryFunctionType = (
   streamQuery: TaggedTemplateLiteralInvocationType,
-  tupleList: ReadonlyArray<readonly any[]>,
-  columnTypes: readonly TypeNameIdentifierType[],
+  tupleList: ReadonlyArray<any[]>,
+  columnTypes: TypeNameIdentifierType[],
 ) => Promise<Record<string, unknown> | null>; // bindPoolConnection returns an object
 
 export type CommonQueryMethodsType = {
@@ -166,12 +166,12 @@ export type QueryResultRowType = Record<string, QueryResultRowColumnType>;
 
 export type QueryType = {
   readonly sql: string,
-  readonly values: readonly PrimitiveValueExpressionType[],
+  readonly values: PrimitiveValueExpressionType[],
 };
 
 export type SqlFragmentType = {
   readonly sql: string,
-  readonly values: readonly PrimitiveValueExpressionType[],
+  readonly values: PrimitiveValueExpressionType[],
 };
 
 /**
@@ -229,14 +229,14 @@ export type QueryContextType = {
   readonly queryId: QueryIdType,
   readonly queryInputTime: bigint | number,
   readonly sandbox: Record<string, unknown>,
-  readonly stackTrace: readonly CallSiteType[] | null,
+  readonly stackTrace: CallSiteType[] | null,
   readonly transactionId?: string,
 };
 
 export type ArraySqlTokenType = {
   readonly memberType: SqlTokenType | TypeNameIdentifierType | string,
   readonly type: typeof tokens.ArrayToken,
-  readonly values: readonly ValueExpressionType[],
+  readonly values: ValueExpressionType[],
 };
 
 export type BinarySqlTokenType = {
@@ -245,13 +245,13 @@ export type BinarySqlTokenType = {
 };
 
 export type IdentifierSqlTokenType = {
-  readonly names: readonly string[],
+  readonly names: string[],
   readonly type: typeof tokens.IdentifierToken,
 };
 
 export type ListSqlTokenType = {
   readonly glue: SqlTokenType,
-  readonly members: readonly ValueExpressionType[],
+  readonly members: ValueExpressionType[],
   readonly type: typeof tokens.ListToken,
 };
 
@@ -263,12 +263,12 @@ export type JsonSqlTokenType = {
 export type SqlSqlTokenType = {
   readonly sql: string,
   readonly type: typeof tokens.SqlToken,
-  readonly values: readonly PrimitiveValueExpressionType[],
+  readonly values: PrimitiveValueExpressionType[],
 };
 
 export type UnnestSqlTokenType = {
-  readonly columnTypes: readonly string[],
-  readonly tuples: ReadonlyArray<readonly ValueExpressionType[]>,
+  readonly columnTypes: string[],
+  readonly tuples: Array<ValueExpressionType[]>,
   readonly type: typeof tokens.UnnestToken,
 };
 
@@ -301,7 +301,7 @@ export type SqlTaggedTemplateType<T = QueryResultRowType> = {
   json: (value: SerializableValueType) => JsonSqlTokenType,
   join: (members: readonly ValueExpressionType[], glue: SqlTokenType) => ListSqlTokenType,
   unnest: (
-    // Value might be $ReadOnlyArray<$ReadOnlyArray<PrimitiveValueExpressionType>>,
+    // Value might be ReadOnlyArray<ReadOnlyArray<PrimitiveValueExpressionType>>,
     // or it can be infinitely nested array, e.g.
     // https://github.com/gajus/slonik/issues/44
     tuples: ReadonlyArray<readonly any[]>,
@@ -361,11 +361,11 @@ export interface TaggedTemplateLiteralInvocationType<Result = QueryResultRowType
 export type QueryAnyFirstFunctionType = <T = QueryResultRowColumnType, Row = Record<string, T>>(
   sql: TaggedTemplateLiteralInvocationType<Row>,
   values?: PrimitiveValueExpressionType[],
-) => Promise<ReadonlyArray<Row[keyof Row]>>;
+) => Promise<Array<Row[keyof Row]>>;
 export type QueryAnyFunctionType = <T = ExternalQueryResultRowType>(
   sql: TaggedTemplateLiteralInvocationType<T>,
   values?: PrimitiveValueExpressionType[],
-) => Promise<readonly T[]>;
+) => Promise<T[]>;
 export type QueryExistsFunctionType = (
   sql: TaggedTemplateLiteralInvocationType,
   values?: PrimitiveValueExpressionType[],
@@ -377,11 +377,11 @@ export type QueryFunctionType = <T = ExternalQueryResultRowType>(
 export type QueryManyFirstFunctionType = <T = QueryResultRowColumnType, Row = Record<string, T>>(
   sql: TaggedTemplateLiteralInvocationType<Row>,
   values?: PrimitiveValueExpressionType[],
-) => Promise<ReadonlyArray<Row[keyof Row]>>;
+) => Promise<Array<Row[keyof Row]>>;
 export type QueryManyFunctionType = <T = ExternalQueryResultRowType>(
   sql: TaggedTemplateLiteralInvocationType<T>,
   values?: PrimitiveValueExpressionType[],
-) => Promise<readonly T[]>;
+) => Promise<T[]>;
 export type QueryMaybeOneFirstFunctionType = <T = QueryResultRowColumnType, Row = Record<string, T>>(
   sql: TaggedTemplateLiteralInvocationType<Row>,
   values?: PrimitiveValueExpressionType[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,7 +105,7 @@ export type StreamFunctionType = (
 
 export type QueryCopyFromBinaryFunctionType = (
   streamQuery: TaggedTemplateLiteralInvocationType,
-  tupleList: ReadonlyArray<any[]>,
+  tupleList: readonly any[][],
   columnTypes: TypeNameIdentifierType[],
 ) => Promise<Record<string, unknown> | null>; // bindPoolConnection returns an object
 
@@ -268,7 +268,7 @@ export type SqlSqlTokenType = {
 
 export type UnnestSqlTokenType = {
   readonly columnTypes: string[],
-  readonly tuples: Array<ValueExpressionType[]>,
+  readonly tuples: ValueExpressionType[][],
   readonly type: typeof tokens.UnnestToken,
 };
 

--- a/test/dts.ts
+++ b/test/dts.ts
@@ -144,11 +144,11 @@ const poolTypes = () => {
 
     expectTypeOf(await pool.maybeOne(getFooBarQuery(10))).toEqualTypeOf<FooBar | null>();
 
-    expectTypeOf(await pool.any(getFooBarQuery(10))).toEqualTypeOf<readonly FooBar[]>();
+    expectTypeOf(await pool.any(getFooBarQuery(10))).toEqualTypeOf<FooBar[]>();
 
-    expectTypeOf(await pool.anyFirst(getFooQuery(10))).toEqualTypeOf<readonly string[]>();
+    expectTypeOf(await pool.anyFirst(getFooQuery(10))).toEqualTypeOf<string[]>();
 
-    expectTypeOf(await pool.anyFirst(getFooBarQuery(10))).toEqualTypeOf<ReadonlyArray<number | string>>();
+    expectTypeOf(await pool.anyFirst(getFooBarQuery(10))).toEqualTypeOf<Array<number | string>>();
   };
 
   createPool('postgres://localhost', {

--- a/test/slonik/integration.ts
+++ b/test/slonik/integration.ts
@@ -1094,6 +1094,7 @@ test('Tuple moved to another partition due to concurrent update error handled', 
         );
         t.true(error instanceof TupleMovedToAnotherPartitionError);
       });
+
       // Ensures that query is processed before concurrent commit is called.
       await delay(1000);
       await connection1.query(sql`COMMIT`);

--- a/test/types.ts
+++ b/test/types.ts
@@ -39,43 +39,43 @@ export const queryMethods = async (): Promise<void> => {
 
   // any
   const any = await client.any(sql``);
-  expectTypeOf(any).toEqualTypeOf<ReadonlyArray<Record<string, PrimitiveValueExpressionType>>>();
+  expectTypeOf(any).toEqualTypeOf<Array<Record<string, PrimitiveValueExpressionType>>>();
 
   const anyTyped = await client.any<Row>(sql``);
-  expectTypeOf(anyTyped).toEqualTypeOf<readonly Row[]>();
+  expectTypeOf(anyTyped).toEqualTypeOf<Row[]>();
 
   const anyTypedQuery = await client.any(sql<Row>``);
-  expectTypeOf(anyTypedQuery).toEqualTypeOf<readonly Row[]>();
+  expectTypeOf(anyTypedQuery).toEqualTypeOf<Row[]>();
 
   // anyFirst
   const anyFirst = await client.anyFirst(sql``);
-  expectTypeOf(anyFirst).toEqualTypeOf<readonly PrimitiveValueExpressionType[]>();
+  expectTypeOf(anyFirst).toEqualTypeOf<PrimitiveValueExpressionType[]>();
 
   const anyFirstTyped = await client.anyFirst<boolean>(sql``);
-  expectTypeOf(anyFirstTyped).toEqualTypeOf<readonly boolean[]>();
+  expectTypeOf(anyFirstTyped).toEqualTypeOf<boolean[]>();
 
   const anyFirstTypedQuery = await client.anyFirst(sql<Row>``);
-  expectTypeOf(anyFirstTypedQuery).toEqualTypeOf<ReadonlyArray<boolean | string>>();
+  expectTypeOf(anyFirstTypedQuery).toEqualTypeOf<Array<boolean | string>>();
 
   // many
   const many = await client.many(sql``);
-  expectTypeOf(many).toEqualTypeOf<ReadonlyArray<Record<string, PrimitiveValueExpressionType>>>();
+  expectTypeOf(many).toEqualTypeOf<Array<Record<string, PrimitiveValueExpressionType>>>();
 
   const manyTyped = await client.many<Row>(sql``);
-  expectTypeOf(manyTyped).toEqualTypeOf<readonly Row[]>();
+  expectTypeOf(manyTyped).toEqualTypeOf<Row[]>();
 
   const manyTypedQuery = await client.many(sql<Row>``);
-  expectTypeOf(manyTypedQuery).toEqualTypeOf<readonly Row[]>();
+  expectTypeOf(manyTypedQuery).toEqualTypeOf<Row[]>();
 
   // manyFirst
   const manyFirst = await client.manyFirst(sql``);
-  expectTypeOf(manyFirst).toEqualTypeOf<readonly PrimitiveValueExpressionType[]>();
+  expectTypeOf(manyFirst).toEqualTypeOf<PrimitiveValueExpressionType[]>();
 
   const manyFirstTyped = await client.manyFirst<boolean>(sql``);
-  expectTypeOf(manyFirstTyped).toEqualTypeOf<readonly boolean[]>();
+  expectTypeOf(manyFirstTyped).toEqualTypeOf<boolean[]>();
 
   const manyFirstTypedQuery = await client.manyFirst(sql<Row>``);
-  expectTypeOf(manyFirstTypedQuery).toEqualTypeOf<ReadonlyArray<boolean | string>>();
+  expectTypeOf(manyFirstTypedQuery).toEqualTypeOf<Array<boolean | string>>();
 
   // maybeOne
   const maybeOne = await client.maybeOne(sql``);


### PR DESCRIPTION
Fixes #218 

Summarising some of the arguments here. As a simple example of the motivation - it allows passing slonik results to regular utility functions:

```ts
const first3 = <T>(list: T[]) => list.slice(0, 3)

const myResults = await pool.any(sql`select * from sometable`)

console.log(first3(myResults))
```

Currently, the above errors unless `first3` is changed to `<T>(list: readonly T[]) => ...`, or the results array is sliced, or uses a type assertion. All of these are unnecessary overhead and will likely lead to developers taking a shortcut and using `any`.