### PR TITLE
Improve type safety for query methods

### DIFF
--- a/src/factories/createSqlTag.ts
+++ b/src/factories/createSqlTag.ts
@@ -162,6 +162,6 @@ sql.unnest = (
   };
 };
 
-export const createSqlTag = <T = QueryResultRowType>(): SqlTaggedTemplateType<T> => {
+export const createSqlTag = <T extends QueryResultRowType = QueryResultRowType>(): SqlTaggedTemplateType<T> => {
   return sql;
 };

--- a/src/sqlFragmentFactories/createBinarySqlFragment.ts
+++ b/src/sqlFragmentFactories/createBinarySqlFragment.ts
@@ -14,7 +14,6 @@ export const createBinarySqlFragment = (token: BinarySqlTokenType, greatestParam
   return {
     sql: '$' + String(greatestParameterPosition + 1),
     values: [
-      // @ts-expect-error
       token.data,
     ],
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -273,7 +273,7 @@ export type UnnestSqlTokenType = {
 };
 
 export type PrimitiveValueExpressionType =
-  boolean | number | string | readonly PrimitiveValueExpressionType[] | null;
+  Buffer | boolean | number | string | readonly PrimitiveValueExpressionType[] | null;
 
 export type SqlTokenType =
   | ArraySqlTokenType
@@ -290,8 +290,8 @@ export type NamedAssignmentType = {
   readonly [key: string]: ValueExpressionType,
 };
 
-export type SqlTaggedTemplateType<T = QueryResultRowType> = {
-  <U = T>(template: TemplateStringsArray, ...values: ValueExpressionType[]): TaggedTemplateLiteralInvocationType<U>,
+export type SqlTaggedTemplateType<T extends QueryResultRowType = QueryResultRowType> = {
+  <U extends QueryResultRowType = T>(template: TemplateStringsArray, ...values: ValueExpressionType[]): TaggedTemplateLiteralInvocationType<U>,
   array: (
     values: readonly PrimitiveValueExpressionType[],
     memberType: SqlTokenType | TypeNameIdentifierType,
@@ -356,13 +356,13 @@ export type InternalNestedTransactionFunctionType = <T>(
 type ExternalQueryResultRowType = Record<string, QueryResultRowColumnType>;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-unused-vars
-export interface TaggedTemplateLiteralInvocationType<Result = QueryResultRowType> extends SqlSqlTokenType { }
+export interface TaggedTemplateLiteralInvocationType<Result extends QueryResultRowType = QueryResultRowType> extends SqlSqlTokenType { }
 
-export type QueryAnyFirstFunctionType = <T = QueryResultRowColumnType, Row = Record<string, T>>(
+export type QueryAnyFirstFunctionType = <T extends QueryResultRowColumnType = QueryResultRowColumnType, Row extends Record<string, T> = Record<string, T>>(
   sql: TaggedTemplateLiteralInvocationType<Row>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<ReadonlyArray<Row[keyof Row]>>;
-export type QueryAnyFunctionType = <T = ExternalQueryResultRowType>(
+export type QueryAnyFunctionType = <T extends ExternalQueryResultRowType = ExternalQueryResultRowType>(
   sql: TaggedTemplateLiteralInvocationType<T>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<readonly T[]>;
@@ -370,31 +370,31 @@ export type QueryExistsFunctionType = (
   sql: TaggedTemplateLiteralInvocationType,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<boolean>;
-export type QueryFunctionType = <T = ExternalQueryResultRowType>(
+export type QueryFunctionType = <T extends ExternalQueryResultRowType = ExternalQueryResultRowType>(
   sql: TaggedTemplateLiteralInvocationType<T>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<QueryResultType<T>>;
-export type QueryManyFirstFunctionType = <T = QueryResultRowColumnType, Row = Record<string, T>>(
+export type QueryManyFirstFunctionType = <T extends QueryResultRowColumnType = QueryResultRowColumnType, Row extends Record<string, T> = Record<string, T>>(
   sql: TaggedTemplateLiteralInvocationType<Row>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<ReadonlyArray<Row[keyof Row]>>;
-export type QueryManyFunctionType = <T = ExternalQueryResultRowType>(
+export type QueryManyFunctionType = <T extends ExternalQueryResultRowType = ExternalQueryResultRowType>(
   sql: TaggedTemplateLiteralInvocationType<T>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<readonly T[]>;
-export type QueryMaybeOneFirstFunctionType = <T = QueryResultRowColumnType, Row = Record<string, T>>(
+export type QueryMaybeOneFirstFunctionType = <T extends QueryResultRowColumnType = QueryResultRowColumnType, Row extends Record<string, T> = Record<string, T>>(
   sql: TaggedTemplateLiteralInvocationType<Row>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<Row[keyof Row] | null>;
-export type QueryMaybeOneFunctionType = <T = ExternalQueryResultRowType>(
+export type QueryMaybeOneFunctionType = <T extends ExternalQueryResultRowType = ExternalQueryResultRowType>(
   sql: TaggedTemplateLiteralInvocationType<T>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<T | null>;
-export type QueryOneFirstFunctionType = <T = QueryResultRowColumnType, Row = Record<string, T>>(
+export type QueryOneFirstFunctionType = <T extends QueryResultRowColumnType = QueryResultRowColumnType, Row extends Record<string, T> = Record<string, T>>(
   sql: TaggedTemplateLiteralInvocationType<Row>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<Row[keyof Row]>;
-export type QueryOneFunctionType = <T = ExternalQueryResultRowType>(
+export type QueryOneFunctionType = <T extends ExternalQueryResultRowType = ExternalQueryResultRowType>(
   sql: TaggedTemplateLiteralInvocationType<T>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<T>;

--- a/test/slonik/integration.ts
+++ b/test/slonik/integration.ts
@@ -381,12 +381,11 @@ test('writes and reads buffers', async (t) => {
     )
   `);
 
-  const result = await pool.oneFirst<{ payload: Buffer, }>(sql`
+  const result = await pool.oneFirst<Buffer>(sql`
     SELECT payload
     FROM person
   `);
 
-  // eslint-disable-next-line @typescript-eslint/no-base-to-string
   t.is(result.toString(), payload);
 
   await pool.end();


### PR DESCRIPTION
The multi-column variants (`any`, `many`, `maybeOne`, `one`, `query`) always return a hash.
The single-column variants (`anyFirst`, `manyFirst`, `maybeOneFirst`, `oneFirst`) always return a single column type.

This PR makes it harder to use the wrong one.

```ts
// correct
connection.any<{ col1: number, col2: string}>(sql`...`)
connection.anyFirst<number>(sql`...`)

// incorrect
connection.any<string>(sql`...`)
connection.anyFirst<{ foo: number }>(sql`...`)
```

This change caught one such bug in the test suite.