### PR TITLE
remove readonly from query result arrays

### DIFF
--- a/src/factories/createMockQueryResult.ts
+++ b/src/factories/createMockQueryResult.ts
@@ -3,7 +3,7 @@ import type {
   QueryResultType,
 } from '../types';
 
-export const createMockQueryResult = (rows: readonly QueryResultRowType[]): QueryResultType<QueryResultRowType> => {
+export const createMockQueryResult = (rows: QueryResultRowType[]): QueryResultType<QueryResultRowType> => {
   return {
     command: 'SELECT',
     fields: [],

--- a/src/routines/executeQuery.ts
+++ b/src/routines/executeQuery.ts
@@ -333,7 +333,7 @@ export const executeQuery = async (
         const transformRow = interceptor.transformRow;
         const fields = result.fields;
 
-        const rows: readonly QueryResultRowType[] = result.rows.map((row) => {
+        const rows: QueryResultRowType[] = result.rows.map((row) => {
           return transformRow(executionContext, actualQuery, row, fields);
         });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,10 +61,10 @@ export type NoticeType = {
 
 export type QueryResultType<T> = {
   readonly command: 'DELETE' | 'INSERT' | 'SELECT' | 'UPDATE',
-  readonly fields: readonly FieldType[],
-  readonly notices: readonly NoticeType[],
+  readonly fields: FieldType[],
+  readonly notices: NoticeType[],
   readonly rowCount: number,
-  readonly rows: readonly T[],
+  readonly rows: T[],
 };
 
 export type InternalDatabasePoolType = any;
@@ -361,11 +361,11 @@ export interface TaggedTemplateLiteralInvocationType<Result extends QueryResultR
 export type QueryAnyFirstFunctionType = <T extends QueryResultRowColumnType = QueryResultRowColumnType, Row extends Record<string, T> = Record<string, T>>(
   sql: TaggedTemplateLiteralInvocationType<Row>,
   values?: PrimitiveValueExpressionType[],
-) => Promise<ReadonlyArray<Row[keyof Row]>>;
+) => Promise<Array<Row[keyof Row]>>;
 export type QueryAnyFunctionType = <T extends ExternalQueryResultRowType = ExternalQueryResultRowType>(
   sql: TaggedTemplateLiteralInvocationType<T>,
   values?: PrimitiveValueExpressionType[],
-) => Promise<readonly T[]>;
+) => Promise<T[]>;
 export type QueryExistsFunctionType = (
   sql: TaggedTemplateLiteralInvocationType,
   values?: PrimitiveValueExpressionType[],
@@ -377,11 +377,11 @@ export type QueryFunctionType = <T extends ExternalQueryResultRowType = External
 export type QueryManyFirstFunctionType = <T extends QueryResultRowColumnType = QueryResultRowColumnType, Row extends Record<string, T> = Record<string, T>>(
   sql: TaggedTemplateLiteralInvocationType<Row>,
   values?: PrimitiveValueExpressionType[],
-) => Promise<ReadonlyArray<Row[keyof Row]>>;
+) => Promise<Array<Row[keyof Row]>>;
 export type QueryManyFunctionType = <T extends ExternalQueryResultRowType = ExternalQueryResultRowType>(
   sql: TaggedTemplateLiteralInvocationType<T>,
   values?: PrimitiveValueExpressionType[],
-) => Promise<readonly T[]>;
+) => Promise<T[]>;
 export type QueryMaybeOneFirstFunctionType = <T extends QueryResultRowColumnType = QueryResultRowColumnType, Row extends Record<string, T> = Record<string, T>>(
   sql: TaggedTemplateLiteralInvocationType<Row>,
   values?: PrimitiveValueExpressionType[],

--- a/test/dts.ts
+++ b/test/dts.ts
@@ -144,11 +144,11 @@ const poolTypes = () => {
 
     expectTypeOf(await pool.maybeOne(getFooBarQuery(10))).toEqualTypeOf<FooBar | null>();
 
-    expectTypeOf(await pool.any(getFooBarQuery(10))).toEqualTypeOf<readonly FooBar[]>();
+    expectTypeOf(await pool.any(getFooBarQuery(10))).toEqualTypeOf<FooBar[]>();
 
-    expectTypeOf(await pool.anyFirst(getFooQuery(10))).toEqualTypeOf<readonly string[]>();
+    expectTypeOf(await pool.anyFirst(getFooQuery(10))).toEqualTypeOf<string[]>();
 
-    expectTypeOf(await pool.anyFirst(getFooBarQuery(10))).toEqualTypeOf<ReadonlyArray<number | string>>();
+    expectTypeOf(await pool.anyFirst(getFooBarQuery(10))).toEqualTypeOf<Array<number | string>>();
   };
 
   createPool('postgres://localhost', {

--- a/test/types.ts
+++ b/test/types.ts
@@ -39,43 +39,43 @@ export const queryMethods = async (): Promise<void> => {
 
   // any
   const any = await client.any(sql``);
-  expectTypeOf(any).toEqualTypeOf<ReadonlyArray<Record<string, PrimitiveValueExpressionType>>>();
+  expectTypeOf(any).toEqualTypeOf<Array<Record<string, PrimitiveValueExpressionType>>>();
 
   const anyTyped = await client.any<Row>(sql``);
-  expectTypeOf(anyTyped).toEqualTypeOf<readonly Row[]>();
+  expectTypeOf(anyTyped).toEqualTypeOf<Row[]>();
 
   const anyTypedQuery = await client.any(sql<Row>``);
-  expectTypeOf(anyTypedQuery).toEqualTypeOf<readonly Row[]>();
+  expectTypeOf(anyTypedQuery).toEqualTypeOf<Row[]>();
 
   // anyFirst
   const anyFirst = await client.anyFirst(sql``);
-  expectTypeOf(anyFirst).toEqualTypeOf<readonly PrimitiveValueExpressionType[]>();
+  expectTypeOf(anyFirst).toEqualTypeOf<PrimitiveValueExpressionType[]>();
 
   const anyFirstTyped = await client.anyFirst<boolean>(sql``);
-  expectTypeOf(anyFirstTyped).toEqualTypeOf<readonly boolean[]>();
+  expectTypeOf(anyFirstTyped).toEqualTypeOf<boolean[]>();
 
   const anyFirstTypedQuery = await client.anyFirst(sql<Row>``);
-  expectTypeOf(anyFirstTypedQuery).toEqualTypeOf<ReadonlyArray<boolean | string>>();
+  expectTypeOf(anyFirstTypedQuery).toEqualTypeOf<Array<boolean | string>>();
 
   // many
   const many = await client.many(sql``);
-  expectTypeOf(many).toEqualTypeOf<ReadonlyArray<Record<string, PrimitiveValueExpressionType>>>();
+  expectTypeOf(many).toEqualTypeOf<Array<Record<string, PrimitiveValueExpressionType>>>();
 
   const manyTyped = await client.many<Row>(sql``);
-  expectTypeOf(manyTyped).toEqualTypeOf<readonly Row[]>();
+  expectTypeOf(manyTyped).toEqualTypeOf<Row[]>();
 
   const manyTypedQuery = await client.many(sql<Row>``);
-  expectTypeOf(manyTypedQuery).toEqualTypeOf<readonly Row[]>();
+  expectTypeOf(manyTypedQuery).toEqualTypeOf<Row[]>();
 
   // manyFirst
   const manyFirst = await client.manyFirst(sql``);
-  expectTypeOf(manyFirst).toEqualTypeOf<readonly PrimitiveValueExpressionType[]>();
+  expectTypeOf(manyFirst).toEqualTypeOf<PrimitiveValueExpressionType[]>();
 
   const manyFirstTyped = await client.manyFirst<boolean>(sql``);
-  expectTypeOf(manyFirstTyped).toEqualTypeOf<readonly boolean[]>();
+  expectTypeOf(manyFirstTyped).toEqualTypeOf<boolean[]>();
 
   const manyFirstTypedQuery = await client.manyFirst(sql<Row>``);
-  expectTypeOf(manyFirstTypedQuery).toEqualTypeOf<ReadonlyArray<boolean | string>>();
+  expectTypeOf(manyFirstTypedQuery).toEqualTypeOf<Array<boolean | string>>();
 
   // maybeOne
   const maybeOne = await client.maybeOne(sql``);
@@ -122,8 +122,8 @@ export const queryMethods = async (): Promise<void> => {
   expectTypeOf(query).toMatchTypeOf<QueryResultType<Record<string, PrimitiveValueExpressionType>>>();
 
   const queryTyped = await client.query<Row>(sql``);
-  expectTypeOf(queryTyped).toMatchTypeOf<{rows: readonly Row[], }>();
+  expectTypeOf(queryTyped).toMatchTypeOf<{rows: Row[], }>();
 
   const queryTypedQuery = await client.query(sql<Row>``);
-  expectTypeOf(queryTypedQuery).toMatchTypeOf<{ rows: readonly Row[], }>();
+  expectTypeOf(queryTypedQuery).toMatchTypeOf<{ rows: Row[], }>();
 };


### PR DESCRIPTION
This PR removes the `readonly` flag from arrays returned by query methods (`query`, `any`,  `anyFirst`, `many`, `manyFirst`).

To summarize #218, this change improves interop between slonik and the broader typescript ecosystem.

This won't break anything for users who want `readonly` still, since `T[]` is assignable to `readonly T[]`:
```ts
// still works
const users: readonly User[] = await connection.any(sql`select * from users`)
```

Fixes #218
Closes #263