### PR TITLE
Allow json types in query methods

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -273,7 +273,7 @@ export type UnnestSqlTokenType = {
 };
 
 export type PrimitiveValueExpressionType =
-  Buffer | boolean | number | string | readonly PrimitiveValueExpressionType[] | null;
+  Buffer | boolean | number | string | object | readonly PrimitiveValueExpressionType[] | null;
 
 export type SqlTokenType =
   | ArraySqlTokenType

--- a/src/types.ts
+++ b/src/types.ts
@@ -273,7 +273,7 @@ export type UnnestSqlTokenType = {
 };
 
 export type PrimitiveValueExpressionType =
-  Buffer | boolean | number | string | object | readonly PrimitiveValueExpressionType[] | null;
+  Buffer | boolean | number | object | string | readonly PrimitiveValueExpressionType[] | null;
 
 export type SqlTokenType =
   | ArraySqlTokenType


### PR DESCRIPTION
In #265 some type safety were enforced. But it caused json types to be considered invalid.

```js
connection.any<{ col1: number, col2: {myJsonColumn: string}}>(sql`...`)
```