### PR TITLE
Fix types for rows with jsonb fields

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -356,16 +356,14 @@ export type InternalNestedTransactionFunctionType = <T>(
   transactionDepth: number,
 ) => Promise<T>;
 
-type ExternalQueryResultRowType = Record<string, QueryResultRowColumnType>;
-
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-unused-vars
 export interface TaggedTemplateLiteralInvocationType<Result extends UserQueryResultRowType = QueryResultRowType> extends SqlSqlTokenType { }
 
-export type QueryAnyFirstFunctionType = <T extends QueryResultRowColumnType = QueryResultRowColumnType, Row extends Record<string, T> = Record<string, T>>(
+export type QueryAnyFirstFunctionType = <T, Row extends Record<string, T> = Record<string, T>>(
   sql: TaggedTemplateLiteralInvocationType<Row>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<ReadonlyArray<Row[keyof Row]>>;
-export type QueryAnyFunctionType = <T extends ExternalQueryResultRowType = ExternalQueryResultRowType>(
+export type QueryAnyFunctionType = <T>(
   sql: TaggedTemplateLiteralInvocationType<T>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<readonly T[]>;
@@ -373,31 +371,31 @@ export type QueryExistsFunctionType = (
   sql: TaggedTemplateLiteralInvocationType,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<boolean>;
-export type QueryFunctionType = <T extends ExternalQueryResultRowType = ExternalQueryResultRowType>(
+export type QueryFunctionType = <T>(
   sql: TaggedTemplateLiteralInvocationType<T>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<QueryResultType<T>>;
-export type QueryManyFirstFunctionType = <T extends QueryResultRowColumnType = QueryResultRowColumnType, Row extends Record<string, T> = Record<string, T>>(
+export type QueryManyFirstFunctionType = <T, Row extends Record<string, T> = Record<string, T>>(
   sql: TaggedTemplateLiteralInvocationType<Row>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<ReadonlyArray<Row[keyof Row]>>;
-export type QueryManyFunctionType = <T extends ExternalQueryResultRowType = ExternalQueryResultRowType>(
+export type QueryManyFunctionType = <T>(
   sql: TaggedTemplateLiteralInvocationType<T>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<readonly T[]>;
-export type QueryMaybeOneFirstFunctionType = <T extends QueryResultRowColumnType = QueryResultRowColumnType, Row extends Record<string, T> = Record<string, T>>(
+export type QueryMaybeOneFirstFunctionType = <T, Row extends Record<string, T> = Record<string, T>>(
   sql: TaggedTemplateLiteralInvocationType<Row>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<Row[keyof Row] | null>;
-export type QueryMaybeOneFunctionType = <T extends ExternalQueryResultRowType = ExternalQueryResultRowType>(
+export type QueryMaybeOneFunctionType = <T>(
   sql: TaggedTemplateLiteralInvocationType<T>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<T | null>;
-export type QueryOneFirstFunctionType = <T extends QueryResultRowColumnType = QueryResultRowColumnType, Row extends Record<string, T> = Record<string, T>>(
+export type QueryOneFirstFunctionType = <T, Row extends Record<string, T> = Record<string, T>>(
   sql: TaggedTemplateLiteralInvocationType<Row>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<Row[keyof Row]>;
-export type QueryOneFunctionType = <T extends ExternalQueryResultRowType = ExternalQueryResultRowType>(
+export type QueryOneFunctionType = <T extends UserQueryResultRowType = UserQueryResultRowType>(
   sql: TaggedTemplateLiteralInvocationType<T>,
   values?: PrimitiveValueExpressionType[],
 ) => Promise<T>;

--- a/test/types.ts
+++ b/test/types.ts
@@ -126,4 +126,22 @@ export const queryMethods = async (): Promise<void> => {
 
   const queryTypedQuery = await client.query(sql<Row>``);
   expectTypeOf(queryTypedQuery).toMatchTypeOf<{ rows: readonly Row[], }>();
+
+  type RowWithJSONB = {
+    foo: {
+      bar: number,
+    },
+  };
+
+  const jsonbSql = sql<RowWithJSONB>`select 123`;
+
+  expectTypeOf(await client.query(jsonbSql)).toEqualTypeOf<QueryResultType<RowWithJSONB>>();
+  expectTypeOf(await client.one(jsonbSql)).toEqualTypeOf<RowWithJSONB>();
+  expectTypeOf(await client.maybeOne(jsonbSql)).toEqualTypeOf<RowWithJSONB | null>();
+  expectTypeOf(await client.any(jsonbSql)).toEqualTypeOf<readonly RowWithJSONB[]>();
+  expectTypeOf(await client.many(jsonbSql)).toEqualTypeOf<readonly RowWithJSONB[]>();
+  expectTypeOf(await client.oneFirst(jsonbSql)).toEqualTypeOf<{ bar: number, }>();
+  expectTypeOf(await client.maybeOneFirst(jsonbSql)).toEqualTypeOf<{ bar: number, } | null>();
+  expectTypeOf(await client.manyFirst(jsonbSql)).toEqualTypeOf<ReadonlyArray<{ bar: number, }>>();
+  expectTypeOf(await client.anyFirst(jsonbSql)).toEqualTypeOf<ReadonlyArray<{ bar: number, }>>();
 };


### PR DESCRIPTION
- [x] test cases reproducing the issue identified in #267 and a few other issues.
- [x] a fix in the types
- [x] full listing of issues and PRs this can close

The first commit 5b17a71 reproduces the problem and the second commit 5e37def fixes it. **I would recommend a squash-and-merge commit to avoid having the intermediate "red" commit in master**.

Since no existing type-level tests regressed, we can be pretty confident that this won't break any further use cases (e.g. we can see that the type restrictions actually _weren't_ helping make the overall type-safety any better, since we have plenty of tests that ensure the various query methods return appropriate types). If anyone can think of more type-level test cases to add, please feel free to comment.

Closes #267 
Closes #276
Related: #268
Related: #270
Related: https://github.com/gajus/slonik/commit/09c7db1611214dfa44d385b84dc7b034e745124b
Related #265 (the PR that caused all the chaos!)

As a follow-up, I think there should be something added to the docs that pushes users away from specifying generics on the query helper methods, preferring instead to put them on the `sql` tag itself, since that's what actually determines the resultant SQL query and the type associated with it, and it allows all queries to be typed in a consistent way. Each of `.query`, `.any`, `.anyFirst`, `.one`, `.oneFirst` have their own unique generic formats, which is very hard - and unnecessary - to keep track of (I say that as the person who originally wrote most of them!). Something along the lines of:

```ts
// bad
await pool.query<{ foo: string }>(sql`select foo from bar`)

// good
await pool.query(sql<{ foo: string }>`select foo from bar`)
```

👆 the `// good` pattern is also how [@slonik/typegen](https://npmjs.com/package/@slonik/typegen) now works.

Side note: @gajus I'm happy to help review future PRs to do with typescript/anything else if it'd be useful!