### PR TITLE
fixed copyFromBinary

### DIFF
--- a/src/connectionMethods/copyFromBinary.ts
+++ b/src/connectionMethods/copyFromBinary.ts
@@ -58,7 +58,7 @@ export const copyFromBinary: InternalCopyFromBinaryFunctionType = async (
           reject(error);
         });
 
-        copyFromBinaryStream.on('end', () => {
+        copyFromBinaryStream.on('finish', () => {
           // @ts-expect-error
           resolve({});
         });

--- a/src/utilities/encodeTupleList.ts
+++ b/src/utilities/encodeTupleList.ts
@@ -3,7 +3,7 @@ import {
 } from 'stream';
 import createConcatStream from 'concat-stream';
 import {
-  deparser as createEncoder,
+  rowWriter as createEncoder,
 } from 'pg-copy-streams-binary';
 import type {
   TypeNameIdentifierType,


### PR DESCRIPTION
This fixes #293. I've updated the `node-pg-copy-streams-binary` API call which fixed the described error. But then the `copyFromBinary` promise still wouldn't resolve. Turns out it was listening to the stream's `end` event instead of `finish`. It now resolves as expected.