### PR TITLE
fix: remove UTC from timestamp with time zone

### DIFF
--- a/src/factories/typeParsers/createTimestampWithTimeZoneTypeParser.ts
+++ b/src/factories/typeParsers/createTimestampWithTimeZoneTypeParser.ts
@@ -3,7 +3,7 @@ import type {
 } from '../../types';
 
 const timestampParser = (value: string | null) => {
-  return value === null ? value : Date.parse(value + ' UTC');
+  return value === null ? value : Date.parse(value);
 };
 
 export const createTimestampWithTimeZoneTypeParser = (): TypeParserType => {


### PR DESCRIPTION
`UTC` was wrongly added to the `timestamp with time zone (timestamptz)`

i.e. result expession will be `Date.parse('2004-10-19 10:23:54+04 UTC')`

ref: https://github.com/gajus/slonik/issues/239#issuecomment-946177310