### PR TITLE
Change query retry handling

### DIFF
--- a/.README/QUERY_METHODS.md
+++ b/.README/QUERY_METHODS.md
@@ -375,6 +375,12 @@ ROLLBACK;
 
 Transactions that are failing with [Transaction Rollback](https://www.postgresql.org/docs/current/errcodes-appendix.html) class errors are automatically retried.
 
-A failing transaction will be rolled back and all queries up to the failing query will be replayed.
+A failing transaction will be rolled back and the callback function passed to the transaction method call will be executed again. Nested transactions are also retried until the retry limit is reached. If the nested transaction keeps failing with a [Transaction Rollback](https://www.postgresql.org/docs/current/errcodes-appendix.html) error, then the parent transaction will be retried until the retry limit is reached.
 
-How many times a transaction is retried is controlled using `transactionRetryLimit` configuration (default: 5).
+How many times a transaction is retried is controlled using `transactionRetryLimit` configuration (default: 5) and the `transactionRetryLimit` parameter of the `transaction` method (default: undefined). If a `transactionRetryLimit` is given to the method call then it is used otherwise the `transactionRetryLimit` configuration is used.
+
+#### Query retrying
+
+A single query (not part of a transaction) failing with a [Transaction Rollback](https://www.postgresql.org/docs/current/errcodes-appendix.html) class error is automatically retried.
+
+How many times it is retried is controlled by using the `queryRetryLimit` configuration (default: 5).

--- a/.README/README.md
+++ b/.README/README.md
@@ -37,6 +37,7 @@ Note: Using this project does not require TypeScript. It is a regular ES6 module
 * [Safe value interpolation](#protecting-against-unsafe-value-interpolation).
 * [Transaction nesting](#transaction-nesting).
 * [Transaction retrying](#transaction-retrying)
+* [Query retrying](#query-retrying)
 * Detailed [logging](#slonik-debugging).
 * [Asynchronous stack trace resolution](#capture-stack-trace).
 * [Middlewares](#slonik-interceptors).

--- a/.README/USAGE.md
+++ b/.README/USAGE.md
@@ -145,6 +145,7 @@ createPool(
  * @property pgClient Override the underlying PostgreSQL client.
  * @property statementTimeout Timeout (in milliseconds) after which database is instructed to abort the query. Use 'DISABLE_TIMEOUT' constant to disable the timeout. (Default: 60000)
  * @property transactionRetryLimit Number of times a transaction failing with Transaction Rollback class error is retried. (Default: 5)
+ * @property queryRetryLimit Number of times a query failing with Transaction Rollback class error, that doesn't belong to a transaction, is retried. (Default: 5)
  * @property typeParsers An array of [Slonik type parsers](https://github.com/gajus/slonik#slonik-type-parsers).
  */
 type ClientConfigurationInputType = {
@@ -158,6 +159,7 @@ type ClientConfigurationInputType = {
   pgClient?: PgClientType,
   statementTimeout?: number | 'DISABLE_TIMEOUT',
   transactionRetryLimit?: number,
+  queryRetryLimit?: number,
   typeParsers?: TypeParserType[],
 };
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Note: Using this project does not require TypeScript. It is a regular ES6 module
 * [Safe value interpolation](#protecting-against-unsafe-value-interpolation).
 * [Transaction nesting](#transaction-nesting).
 * [Transaction retrying](#transaction-retrying)
+* [Query retrying](#query-retrying)
 * Detailed [logging](#slonik-debugging).
 * [Asynchronous stack trace resolution](#capture-stack-trace).
 * [Middlewares](#slonik-interceptors).
@@ -546,6 +547,7 @@ createPool(
  * @property pgClient Override the underlying PostgreSQL client.
  * @property statementTimeout Timeout (in milliseconds) after which database is instructed to abort the query. Use 'DISABLE_TIMEOUT' constant to disable the timeout. (Default: 60000)
  * @property transactionRetryLimit Number of times a transaction failing with Transaction Rollback class error is retried. (Default: 5)
+ * @property queryRetryLimit Number of times a query failing with Transaction Rollback class error, that doesn't belong to a transaction, is retried. (Default: 5)
  * @property typeParsers An array of [Slonik type parsers](https://github.com/gajus/slonik#slonik-type-parsers).
  */
 type ClientConfigurationInputType = {
@@ -559,6 +561,7 @@ type ClientConfigurationInputType = {
   pgClient?: PgClientType,
   statementTimeout?: number | 'DISABLE_TIMEOUT',
   transactionRetryLimit?: number,
+  queryRetryLimit?: number,
   typeParsers?: TypeParserType[],
 };
 
@@ -1992,9 +1995,16 @@ ROLLBACK;
 
 Transactions that are failing with [Transaction Rollback](https://www.postgresql.org/docs/current/errcodes-appendix.html) class errors are automatically retried.
 
-A failing transaction will be rolled back and all queries up to the failing query will be replayed.
+A failing transaction will be rolled back and the callback function passed to the transaction method call will be executed again. Nested transactions are also retried until the retry limit is reached. If the nested transaction keeps failing with a [Transaction Rollback](https://www.postgresql.org/docs/current/errcodes-appendix.html) error, then the parent transaction will be retried until the retry limit is reached.
 
-How many times a transaction is retried is controlled using `transactionRetryLimit` configuration (default: 5).
+How many times a transaction is retried is controlled using `transactionRetryLimit` configuration (default: 5) and the `transactionRetryLimit` parameter of the `transaction` method (default: undefined). If a `transactionRetryLimit` is given to the method call then it is used otherwise the `transactionRetryLimit` configuration is used.
+
+<a name="slonik-query-methods-transaction-query-retrying"></a>
+#### Query retrying
+
+A single query (not part of a transaction) failing with a [Transaction Rollback](https://www.postgresql.org/docs/current/errcodes-appendix.html) class error is automatically retried.
+
+How many times it is retried is controlled by using the `queryRetryLimit` configuration (default: 5).
 
 
 <a name="slonik-error-handling"></a>

--- a/src/binders/bindPool.ts
+++ b/src/binders/bindPool.ts
@@ -144,14 +144,14 @@ export const bindPool = (
         streamQuery,
       );
     },
-    transaction: async (transactionHandler) => {
+    transaction: async (transactionHandler, transactionRetryLimit) => {
       return createConnection(
         parentLog,
         pool,
         clientConfiguration,
         'IMPLICIT_TRANSACTION',
         (connectionLog, connection) => {
-          return transaction(connectionLog, connection, clientConfiguration, transactionHandler);
+          return transaction(connectionLog, connection, clientConfiguration, transactionHandler, transactionRetryLimit);
         },
         (newPool) => {
           return newPool.transaction(transactionHandler);

--- a/src/binders/bindPoolConnection.ts
+++ b/src/binders/bindPoolConnection.ts
@@ -164,12 +164,13 @@ export const bindPoolConnection = (
         streamHandler,
       );
     },
-    transaction: (handler) => {
+    transaction: (handler, transactionRetryLimit) => {
       return transaction(
         parentLog,
         connection,
         clientConfiguration,
         handler,
+        transactionRetryLimit,
       );
     },
   };

--- a/src/binders/bindTransactionConnection.ts
+++ b/src/binders/bindTransactionConnection.ts
@@ -168,7 +168,7 @@ export const bindTransactionConnection = (
         streamHandler,
       );
     },
-    transaction: (handler) => {
+    transaction: (handler, transactionRetryLimit) => {
       assertTransactionDepth();
 
       return nestedTransaction(
@@ -177,6 +177,7 @@ export const bindTransactionConnection = (
         clientConfiguration,
         handler,
         transactionDepth,
+        transactionRetryLimit,
       );
     },
   };

--- a/src/connectionMethods/nestedTransaction.ts
+++ b/src/connectionMethods/nestedTransaction.ts
@@ -4,6 +4,9 @@ import {
 import {
   bindTransactionConnection,
 } from '../binders';
+import {
+  TRANSACTION_ROLLBACK_ERROR_PREFIX,
+} from '../constants';
 import type {
   InternalNestedTransactionFunctionType,
 } from '../types';
@@ -11,12 +14,82 @@ import {
   createUid,
 } from '../utilities';
 
-export const nestedTransaction: InternalNestedTransactionFunctionType = async (parentLog, connection, clientConfiguration, handler, transactionDepth) => {
-  const newTransactionDepth = transactionDepth + 1;
-
+const execNestedTransaction: InternalNestedTransactionFunctionType = async (parentLog, connection, clientConfiguration, handler, newTransactionDepth) => {
   if (connection.connection.slonik.mock === false) {
     await connection.query('SAVEPOINT slonik_savepoint_' + String(newTransactionDepth));
   }
+
+  try {
+    const result = await handler(bindTransactionConnection(
+      parentLog,
+      connection,
+      clientConfiguration,
+      newTransactionDepth,
+    ));
+
+    return result;
+  } catch (error) {
+    if (connection.connection.slonik.mock === false) {
+      await connection.query('ROLLBACK TO SAVEPOINT slonik_savepoint_' + String(newTransactionDepth));
+    }
+
+    parentLog.error({
+      error: serializeError(error),
+    }, 'rolling back transaction due to an error');
+
+    throw error;
+  }
+};
+
+type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
+
+const retryNestedTransaction: InternalNestedTransactionFunctionType = async (
+  parentLog,
+  connection,
+  clientConfiguration,
+  handler,
+  transactionDepth,
+  transactionRetryLimit,
+) => {
+  let remainingRetries = transactionRetryLimit ?? clientConfiguration.transactionRetryLimit;
+  let attempt = 0;
+  let result: Awaited<ReturnType<typeof handler>>;
+
+  while (remainingRetries-- > 0) {
+    attempt++;
+
+    try {
+      parentLog.trace({
+        attempt,
+        parentTransactionId: connection.connection.slonik.transactionId,
+      }, 'retrying nested transaction');
+
+      result = await execNestedTransaction(parentLog, connection, clientConfiguration, handler, transactionDepth);
+
+      // If the attempt succeeded break out of the loop
+      break;
+    } catch (error) {
+      if (typeof error.code === 'string' && error.code.startsWith(TRANSACTION_ROLLBACK_ERROR_PREFIX) && remainingRetries > 0) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return result!;
+};
+
+export const nestedTransaction: InternalNestedTransactionFunctionType = async (
+  parentLog,
+  connection,
+  clientConfiguration,
+  handler,
+  transactionDepth,
+  transactionRetryLimit,
+) => {
+  const newTransactionDepth = transactionDepth + 1;
 
   const log = parentLog.child({
     transactionId: createUid(),
@@ -25,19 +98,17 @@ export const nestedTransaction: InternalNestedTransactionFunctionType = async (p
   try {
     connection.connection.slonik.transactionDepth = newTransactionDepth;
 
-    const result = await handler(bindTransactionConnection(log, connection, clientConfiguration, newTransactionDepth));
-
-    return result;
+    return await execNestedTransaction(log, connection, clientConfiguration, handler, newTransactionDepth);
   } catch (error) {
-    if (connection.connection.slonik.mock === false) {
-      await connection.query('ROLLBACK TO SAVEPOINT slonik_savepoint_' + String(newTransactionDepth));
+    const transactionRetryLimitToUse = transactionRetryLimit ?? clientConfiguration.transactionRetryLimit;
+
+    const shouldRetry = typeof error.code === 'string' && error.code.startsWith(TRANSACTION_ROLLBACK_ERROR_PREFIX) && transactionRetryLimitToUse > 0;
+
+    if (shouldRetry) {
+      return await retryNestedTransaction(parentLog, connection, clientConfiguration, handler, newTransactionDepth, transactionRetryLimit);
+    } else {
+      throw error;
     }
-
-    log.error({
-      error: serializeError(error),
-    }, 'rolling back transaction due to an error');
-
-    throw error;
   } finally {
     connection.connection.slonik.transactionDepth = newTransactionDepth - 1;
   }

--- a/src/connectionMethods/transaction.ts
+++ b/src/connectionMethods/transaction.ts
@@ -5,6 +5,9 @@ import {
   bindTransactionConnection,
 } from '../binders';
 import {
+  TRANSACTION_ROLLBACK_ERROR_PREFIX,
+} from '../constants';
+import {
   BackendTerminatedError,
   UnexpectedStateError,
 } from '../errors';
@@ -15,26 +18,14 @@ import {
   createUid,
 } from '../utilities';
 
-export const transaction: InternalTransactionFunctionType = async (parentLog, connection, clientConfiguration, handler) => {
-  if (connection.connection.slonik.transactionDepth !== null) {
-    throw new UnexpectedStateError('Cannot use the same connection to start a new transaction before completing the last transaction.');
-  }
-
-  connection.connection.slonik.transactionDepth = 0;
-  connection.connection.slonik.transactionId = createUid();
-  connection.connection.slonik.transactionQueries = [];
-
+const execTransaction: InternalTransactionFunctionType = async (parentLog, connection, clientConfiguration, handler) => {
   if (connection.connection.slonik.mock === false) {
     await connection.query('START TRANSACTION');
   }
 
-  const log = parentLog.child({
-    transactionId: connection.connection.slonik.transactionId,
-  });
-
   try {
     const result = await handler(bindTransactionConnection(
-      log,
+      parentLog,
       connection,
       clientConfiguration,
       connection.connection.slonik.transactionDepth,
@@ -55,15 +46,74 @@ export const transaction: InternalTransactionFunctionType = async (parentLog, co
         await connection.query('ROLLBACK');
       }
 
-      log.error({
+      parentLog.error({
         error: serializeError(error),
       }, 'rolling back transaction due to an error');
     }
 
     throw error;
+  }
+};
+
+type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
+
+const retryTransaction: InternalTransactionFunctionType = async (parentLog, connection, clientConfiguration, handler, transactionRetryLimit) => {
+  let remainingRetries = transactionRetryLimit ?? clientConfiguration.transactionRetryLimit;
+  let attempt = 0;
+  let result: Awaited<ReturnType<typeof handler>>;
+
+  while (remainingRetries-- > 0) {
+    attempt++;
+
+    try {
+      parentLog.trace({
+        attempt,
+        transactionId: connection.connection.slonik.transactionId,
+      }, 'retrying transaction');
+
+      result = await execTransaction(parentLog, connection, clientConfiguration, handler);
+
+      // If the attempt succeeded break out of the loop
+      break;
+    } catch (error) {
+      if (typeof error.code === 'string' && error.code.startsWith(TRANSACTION_ROLLBACK_ERROR_PREFIX) && remainingRetries > 0) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return result!;
+};
+
+export const transaction: InternalTransactionFunctionType = async (parentLog, connection, clientConfiguration, handler, transactionRetryLimit) => {
+  if (connection.connection.slonik.transactionDepth !== null) {
+    throw new UnexpectedStateError('Cannot use the same connection to start a new transaction before completing the last transaction.');
+  }
+
+  connection.connection.slonik.transactionDepth = 0;
+  connection.connection.slonik.transactionId = createUid();
+
+  const log = parentLog.child({
+    transactionId: connection.connection.slonik.transactionId,
+  });
+
+  try {
+    return await execTransaction(log, connection, clientConfiguration, handler);
+  } catch (error) {
+    const transactionRetryLimitToUse = transactionRetryLimit ?? clientConfiguration.transactionRetryLimit;
+
+    const shouldRetry = typeof error.code === 'string' && error.code.startsWith(TRANSACTION_ROLLBACK_ERROR_PREFIX) && transactionRetryLimitToUse > 0;
+
+    if (shouldRetry) {
+      return await retryTransaction(log, connection, clientConfiguration, handler, transactionRetryLimit);
+    } else {
+      throw error;
+    }
   } finally {
     connection.connection.slonik.transactionDepth = null;
     connection.connection.slonik.transactionId = null;
-    connection.connection.slonik.transactionQueries = null;
   }
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+// @see https://www.postgresql.org/docs/current/errcodes-appendix.html
+export const TRANSACTION_ROLLBACK_ERROR_PREFIX = '40';

--- a/src/factories/createClientConfiguration.ts
+++ b/src/factories/createClientConfiguration.ts
@@ -21,6 +21,7 @@ export const createClientConfiguration = (clientUserConfigurationInput?: ClientC
     idleTimeout: 5000,
     interceptors: [],
     maximumPoolSize: 10,
+    queryRetryLimit: 5,
     statementTimeout: 60000,
     transactionRetryLimit: 5,
     typeParsers,

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,8 @@ export type ClientConfigurationType = {
   readonly statementTimeout: number | 'DISABLE_TIMEOUT',
   /** Number of times a transaction failing with Transaction Rollback class error is retried. (Default: 5) */
   readonly transactionRetryLimit: number,
+  /** Number of times a query failing with Transaction Rollback class error, that doesn't belong to a transaction, is retried. (Default: 5) */
+  readonly queryRetryLimit: number,
   /** An array of [Slonik type parsers](https://github.com/gajus/slonik#slonik-type-parsers). */
   readonly typeParsers: readonly TypeParserType[],
 };
@@ -127,7 +129,7 @@ export type CommonQueryMethodsType = {
 
 export type DatabaseTransactionConnectionType = CommonQueryMethodsType & {
   readonly stream: StreamFunctionType,
-  readonly transaction: <T>(handler: TransactionFunctionType<T>) => Promise<T>,
+  readonly transaction: <T>(handler: TransactionFunctionType<T>, transactionRetryLimit?: number) => Promise<T>,
 };
 
 export type TransactionFunctionType<T> = (connection: DatabaseTransactionConnectionType) => Promise<T>;
@@ -135,7 +137,7 @@ export type TransactionFunctionType<T> = (connection: DatabaseTransactionConnect
 export type DatabasePoolConnectionType = CommonQueryMethodsType & {
   readonly copyFromBinary: QueryCopyFromBinaryFunctionType,
   readonly stream: StreamFunctionType,
-  readonly transaction: <T>(handler: TransactionFunctionType<T>) => Promise<T>,
+  readonly transaction: <T>(handler: TransactionFunctionType<T>, transactionRetryLimit?: number) => Promise<T>,
 };
 
 export type ConnectionRoutineType<T> = (connection: DatabasePoolConnectionType) => Promise<T>;
@@ -153,7 +155,7 @@ export type DatabasePoolType = CommonQueryMethodsType & {
   readonly end: () => Promise<void>,
   readonly getPoolState: () => PoolStateType,
   readonly stream: StreamFunctionType,
-  readonly transaction: <T>(handler: TransactionFunctionType<T>) => Promise<T>,
+  readonly transaction: <T>(handler: TransactionFunctionType<T>, transactionRetryLimit?: number) => Promise<T>,
   readonly configuration: ClientConfigurationType,
 };
 
@@ -351,6 +353,7 @@ export type InternalTransactionFunctionType = <T>(
   connection: InternalDatabaseConnectionType,
   clientConfiguration: ClientConfigurationType,
   handler: TransactionFunctionType<T>,
+  transactionRetryLimit?: number,
 ) => Promise<T>;
 
 export type InternalNestedTransactionFunctionType = <T>(
@@ -359,6 +362,7 @@ export type InternalNestedTransactionFunctionType = <T>(
   clientConfiguration: ClientConfigurationType,
   handler: TransactionFunctionType<T>,
   transactionDepth: number,
+  transactionRetryLimit?: number,
 ) => Promise<T>;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-unused-vars

--- a/test/helpers/createClientConfiguration.ts
+++ b/test/helpers/createClientConfiguration.ts
@@ -11,6 +11,7 @@ export const createClientConfiguration = (): ClientConfigurationType => {
     idleTimeout: 5000,
     interceptors: [],
     maximumPoolSize: 10,
+    queryRetryLimit: 5,
     statementTimeout: 60000,
     transactionRetryLimit: 5,
     typeParsers: [],

--- a/test/helpers/createErrorWithCode.ts
+++ b/test/helpers/createErrorWithCode.ts
@@ -1,0 +1,8 @@
+export const createErrorWithCode = (code: string) => {
+  const error = new Error('foo');
+
+  // @ts-expect-error
+  error.code = code;
+
+  return error;
+};

--- a/test/helpers/createIntegrationTests.ts
+++ b/test/helpers/createIntegrationTests.ts
@@ -927,7 +927,7 @@ export const createIntegrationTests = (
   test('Tuple moved to another partition due to concurrent update error handled', async (t) => {
     const pool = createPool(t.context.dsn, {
       pgClient,
-      transactionRetryLimit: 0,
+      queryRetryLimit: 0,
     });
 
     await pool.connect(async (connection) => {

--- a/test/slonik/connectionMethods/nestedTransaction.ts
+++ b/test/slonik/connectionMethods/nestedTransaction.ts
@@ -1,0 +1,141 @@
+import test from 'ava';
+import sinon from 'sinon';
+import {
+  createClientConfiguration,
+} from '../../helpers/createClientConfiguration';
+import {
+  createErrorWithCode,
+} from '../../helpers/createErrorWithCode';
+import {
+  createPool,
+} from '../../helpers/createPool';
+
+test('creates a savepoint', async (t) => {
+  const pool = createPool();
+
+  await pool.transaction(async (transactionConnection) => {
+    return transactionConnection.transaction(async () => {});
+  });
+
+  t.assert(pool.querySpy.getCall(0).args[0] === 'START TRANSACTION');
+  t.assert(pool.querySpy.getCall(1).args[0] === 'SAVEPOINT slonik_savepoint_1');
+});
+
+test('rollbacks unsuccessful nested transaction', async (t) => {
+  const pool = createPool();
+
+  await t.throwsAsync(pool.transaction(async (transactionConnection) => {
+    return transactionConnection.transaction(async () => {
+      return Promise.reject(new Error('foo'));
+    });
+  }));
+
+  t.assert(pool.querySpy.getCall(1).args[0] === 'SAVEPOINT slonik_savepoint_1');
+  t.assert(pool.querySpy.getCall(2).args[0] === 'ROLLBACK TO SAVEPOINT slonik_savepoint_1');
+});
+
+test('retries a nested transaction that failed due to a transaction error', async (t) => {
+  const pool = createPool(createClientConfiguration());
+  const handlerStub = sinon.stub();
+
+  handlerStub.onFirstCall()
+    .rejects(createErrorWithCode('40P01'))
+    .onSecondCall()
+    .resolves({
+      command: 'SELECT',
+      fields: [],
+      notices: [],
+      rowCount: 1,
+      rows: [
+        {
+          foo: 1,
+        },
+      ],
+    });
+
+  const result = await pool.transaction(async (transactionConnection) => {
+    return transactionConnection.transaction(handlerStub);
+  });
+
+  t.assert(handlerStub.callCount === 2);
+  t.deepEqual(result, {
+    command: 'SELECT',
+    fields: [],
+    notices: [],
+    rowCount: 1,
+    rows: [
+      {
+        foo: 1,
+      },
+    ],
+  });
+});
+
+test('commits successful transaction with retries', async (t) => {
+  const pool = createPool(createClientConfiguration());
+  const handlerStub = sinon.stub();
+
+  handlerStub.onFirstCall()
+    .rejects(createErrorWithCode('40P01'))
+    .onSecondCall()
+    .resolves({
+      command: 'SELECT',
+      fields: [],
+      notices: [],
+      rowCount: 1,
+      rows: [
+        {
+          foo: 1,
+        },
+      ],
+    });
+
+  await pool.transaction(async (transactionConnection) => {
+    return transactionConnection.transaction(handlerStub);
+  });
+
+  t.assert(pool.querySpy.getCall(1).args[0] === 'SAVEPOINT slonik_savepoint_1');
+  t.assert(pool.querySpy.getCall(2).args[0] === 'ROLLBACK TO SAVEPOINT slonik_savepoint_1');
+  t.assert(pool.querySpy.getCall(3).args[0] === 'SAVEPOINT slonik_savepoint_1');
+  t.assert(pool.querySpy.getCall(4).args[0] === 'COMMIT');
+});
+
+test('returns the thrown transaction error if the retry limit is reached', async (t) => {
+  const clientConfiguration = createClientConfiguration();
+
+  const pool = createPool(clientConfiguration);
+  const handlerStub = sinon.stub();
+
+  handlerStub.onFirstCall()
+    .rejects(createErrorWithCode('40P01'))
+    .onSecondCall()
+    .rejects(createErrorWithCode('40P01'));
+
+  const error: Error & {code: string, } = await t.throwsAsync(pool.transaction(async (transactionConnection) => {
+    return transactionConnection.transaction(handlerStub, 1);
+  }, 0));
+
+  t.assert(handlerStub.callCount === 2);
+
+  t.assert(error instanceof Error);
+  t.assert(error.code === '40P01');
+});
+
+test('rollbacks unsuccessful nested transaction with retries', async (t) => {
+  const pool = createPool(createClientConfiguration());
+  const handlerStub = sinon.stub();
+
+  handlerStub.onFirstCall()
+    .rejects(createErrorWithCode('40P01'))
+    .onSecondCall()
+    .rejects(createErrorWithCode('40P01'));
+
+  await t.throwsAsync(pool.transaction(async (transactionConnection) => {
+    return transactionConnection.transaction(handlerStub, 1);
+  }, 0));
+
+  t.assert(pool.querySpy.getCall(1).args[0] === 'SAVEPOINT slonik_savepoint_1');
+  t.assert(pool.querySpy.getCall(2).args[0] === 'ROLLBACK TO SAVEPOINT slonik_savepoint_1');
+  t.assert(pool.querySpy.getCall(3).args[0] === 'SAVEPOINT slonik_savepoint_1');
+  t.assert(pool.querySpy.getCall(4).args[0] === 'ROLLBACK TO SAVEPOINT slonik_savepoint_1');
+});

--- a/test/slonik/connectionMethods/query/query.ts
+++ b/test/slonik/connectionMethods/query/query.ts
@@ -12,19 +12,13 @@ import {
   createSqlTag,
 } from '../../../../src/factories/createSqlTag';
 import {
+  createErrorWithCode,
+} from '../../../helpers/createErrorWithCode';
+import {
   createPool,
 } from '../../../helpers/createPool';
 
 const sql = createSqlTag();
-
-const createErrorWithCode = (code: string) => {
-  const error = new Error('foo');
-
-  // @ts-expect-error
-  error.code = code;
-
-  return error;
-};
 
 test('ends connection after promise is resolved (explicit connection)', async (t) => {
   const eventHandler = sinon.spy();

--- a/test/slonik/connectionMethods/transaction.ts
+++ b/test/slonik/connectionMethods/transaction.ts
@@ -1,4 +1,11 @@
 import test from 'ava';
+import sinon from 'sinon';
+import {
+  createClientConfiguration,
+} from '../../helpers/createClientConfiguration';
+import {
+  createErrorWithCode,
+} from '../../helpers/createErrorWithCode';
 import {
   createPool,
 } from '../../helpers/createPool';
@@ -21,4 +28,100 @@ test('rollbacks unsuccessful transaction', async (t) => {
 
   t.assert(pool.querySpy.getCall(0).args[0] === 'START TRANSACTION');
   t.assert(pool.querySpy.getCall(1).args[0] === 'ROLLBACK');
+});
+
+test('retries a transaction that failed due to a transaction error', async (t) => {
+  const pool = createPool(createClientConfiguration());
+  const handlerStub = sinon.stub();
+
+  handlerStub.onFirstCall()
+    .rejects(createErrorWithCode('40P01'))
+    .onSecondCall()
+    .resolves({
+      command: 'SELECT',
+      fields: [],
+      notices: [],
+      rowCount: 1,
+      rows: [
+        {
+          foo: 1,
+        },
+      ],
+    });
+
+  const result = await pool.transaction(handlerStub);
+
+  t.assert(handlerStub.callCount === 2);
+  t.deepEqual(result, {
+    command: 'SELECT',
+    fields: [],
+    notices: [],
+    rowCount: 1,
+    rows: [
+      {
+        foo: 1,
+      },
+    ],
+  });
+});
+
+test('commits successful transaction with retries', async (t) => {
+  const pool = createPool(createClientConfiguration());
+  const handlerStub = sinon.stub();
+
+  handlerStub.onFirstCall()
+    .rejects(createErrorWithCode('40P01'))
+    .onSecondCall()
+    .resolves({
+      command: 'SELECT',
+      fields: [],
+      notices: [],
+      rowCount: 1,
+      rows: [
+        {
+          foo: 1,
+        },
+      ],
+    });
+
+  await pool.transaction(handlerStub);
+
+  t.assert(pool.querySpy.getCall(0).args[0] === 'START TRANSACTION');
+  t.assert(pool.querySpy.getCall(1).args[0] === 'ROLLBACK');
+  t.assert(pool.querySpy.getCall(2).args[0] === 'START TRANSACTION');
+  t.assert(pool.querySpy.getCall(3).args[0] === 'COMMIT');
+});
+
+test('returns the thrown transaction error if the retry limit is reached', async (t) => {
+  const pool = createPool(createClientConfiguration());
+  const handlerStub = sinon.stub();
+
+  handlerStub.onFirstCall()
+    .rejects(createErrorWithCode('40P01'))
+    .onSecondCall()
+    .rejects(createErrorWithCode('40P01'));
+
+  const error: Error & {code: string, } = await t.throwsAsync(pool.transaction(handlerStub, 1));
+
+  t.assert(handlerStub.callCount === 2);
+
+  t.assert(error instanceof Error);
+  t.assert(error.code === '40P01');
+});
+
+test('rollbacks unsuccessful transaction with retries', async (t) => {
+  const pool = createPool(createClientConfiguration());
+  const handlerStub = sinon.stub();
+
+  handlerStub.onFirstCall()
+    .rejects(createErrorWithCode('40P01'))
+    .onSecondCall()
+    .rejects(createErrorWithCode('40P01'));
+
+  await t.throwsAsync(pool.transaction(handlerStub, 1));
+
+  t.assert(pool.querySpy.getCall(0).args[0] === 'START TRANSACTION');
+  t.assert(pool.querySpy.getCall(1).args[0] === 'ROLLBACK');
+  t.assert(pool.querySpy.getCall(2).args[0] === 'START TRANSACTION');
+  t.assert(pool.querySpy.getCall(3).args[0] === 'ROLLBACK');
 });

--- a/test/slonik/factories/createClientConfiguration.ts
+++ b/test/slonik/factories/createClientConfiguration.ts
@@ -14,6 +14,7 @@ const defaultConfiguration = {
   idleTimeout: 5000,
   interceptors: [],
   maximumPoolSize: 10,
+  queryRetryLimit: 5,
   statementTimeout: 60000,
   transactionRetryLimit: 5,
   typeParsers: createTypeParserPreset(),


### PR DESCRIPTION
Move transaction retry handling to the transaction and nestedTransaction
methods and change it so that the handler function is called again
instead of just replaying the queries that are part of the transaction.
Fixes #163.

Add a second parameter to the transaction method to allow users to
define a retry limit per transaction. If a retry limit is given for a
transaction then the global defined retry limit for transactions is
ignored.

Change executeQuery so that it retries individual queries that failed
with a transaction rollback error. Only queries that are not part of a
transaction are retried. The number of times a query is retried is
specified by the global queryRetryLimit configuration. Fixes #176.

The above change also fixes #196 since the transactionQueries array no
longer exists.