### PR TITLE
preserve ssl options

### DIFF
--- a/src/factories/createPoolConfiguration.ts
+++ b/src/factories/createPoolConfiguration.ts
@@ -29,11 +29,28 @@ export const createPoolConfiguration = (dsn: string, clientConfiguration: Client
   if (connectionOptions.sslMode === 'disable') {
     poolConfiguration.ssl = false;
   } else if (connectionOptions.sslMode === 'require') {
-    poolConfiguration.ssl = true;
+    
+    if (clientConfiguration.ssl) {
+      poolConfiguration.ssl = {
+        ...clientConfiguration.ssl,
+        rejectUnauthorized: true,
+      }
+    } else {
+      poolConfiguration.ssl = true;
+    }
+
   } else if (connectionOptions.sslMode === 'no-verify') {
-    poolConfiguration.ssl = {
-      rejectUnauthorized: false,
-    };
+
+    if (clientConfiguration.ssl) {
+      poolConfiguration.ssl = {
+        ...clientConfiguration.ssl,
+        rejectUnauthorized: false,
+      }
+    } else {
+      poolConfiguration.ssl = {
+        rejectUnauthorized: false,
+      };
+    }
   }
 
   if (clientConfiguration.connectionTimeout !== 'DISABLE_TIMEOUT') {

--- a/src/factories/createPoolConfiguration.ts
+++ b/src/factories/createPoolConfiguration.ts
@@ -29,23 +29,20 @@ export const createPoolConfiguration = (dsn: string, clientConfiguration: Client
   if (connectionOptions.sslMode === 'disable') {
     poolConfiguration.ssl = false;
   } else if (connectionOptions.sslMode === 'require') {
-    
     if (clientConfiguration.ssl) {
       poolConfiguration.ssl = {
         ...clientConfiguration.ssl,
         rejectUnauthorized: true,
-      }
+      };
     } else {
       poolConfiguration.ssl = true;
     }
-
   } else if (connectionOptions.sslMode === 'no-verify') {
-
     if (clientConfiguration.ssl) {
       poolConfiguration.ssl = {
         ...clientConfiguration.ssl,
         rejectUnauthorized: false,
-      }
+      };
     } else {
       poolConfiguration.ssl = {
         rejectUnauthorized: false,


### PR DESCRIPTION
The library allows to specify custom ssl options like this:
```
const ca = readFileSync('/etc/ssl/ca.crt', 'utf8');
export const pool = createPool(pgUrl, {ssl: {ca},});
```
However these ssl options are overridden:
https://github.com/gajus/slonik/blob/master/src/factories/createPoolConfiguration.ts#L29
 
So it seams the library discards user provided ssl options like custom certificate authority. 

In this pull request ssl options are preserved