### PR TITLE
Make sure that parts of DSN are properly decoded

### DIFF
--- a/src/utilities/parseDsn.ts
+++ b/src/utilities/parseDsn.ts
@@ -30,15 +30,15 @@ export const parseDsn = (dsn: string): ConnectionOptions => {
   }
 
   if (url.pathname && url.pathname !== '/') {
-    connectionOptions.databaseName = url.pathname.split('/')[1];
+    connectionOptions.databaseName = decodeURIComponent(url.pathname.split('/')[1]);
   }
 
   if (url.username) {
-    connectionOptions.username = url.username;
+    connectionOptions.username = decodeURIComponent(url.username);
   }
 
   if (url.password) {
-    connectionOptions.password = url.password;
+    connectionOptions.password = decodeURIComponent(url.password);
   }
 
   const {

--- a/src/utilities/stringifyDsn.ts
+++ b/src/utilities/stringifyDsn.ts
@@ -24,13 +24,13 @@ export const stringifyDsn = (connectionOptions: ConnectionOptions): string => {
 
   if (username) {
     tokens.push(
-      username,
+      encodeURIComponent(username),
     );
 
     if (password) {
       tokens.push(
         ':',
-        password,
+        encodeURIComponent(password),
       );
     }
 
@@ -49,7 +49,7 @@ export const stringifyDsn = (connectionOptions: ConnectionOptions): string => {
   if (databaseName) {
     tokens.push(
       '/',
-      databaseName,
+      encodeURIComponent(databaseName),
     );
   }
 

--- a/test/slonik/utilities/parseDsn.ts
+++ b/test/slonik/utilities/parseDsn.ts
@@ -36,3 +36,9 @@ test('postgresql://localhost/?&application_name=baz', testParse, {
   applicationName: 'baz',
   host: 'localhost',
 });
+test('postgresql://fo%2Fo:b%2Far@localhost/ba%2Fz', testParse, {
+  databaseName: 'ba/z',
+  host: 'localhost',
+  password: 'b/ar',
+  username: 'fo/o',
+});

--- a/test/slonik/utilities/stringifyDsn.ts
+++ b/test/slonik/utilities/stringifyDsn.ts
@@ -14,6 +14,7 @@ const dsns = [
   'postgresql://foo@localhost/bar',
   'postgresql://foo@localhost/bar?application_name=foo',
   'postgresql://foo@localhost/bar?sslmode=no-verify',
+  'postgresql://fo%2Fo:b%2Far@localhost/ba%2Fz',
 ];
 
 for (const dsn of dsns) {


### PR DESCRIPTION
DB-connection parameters might have url-incompatible characters in them (such as `/`). The standard way of dealing with this is urlencoding.

Slonik's old DSN parser supported it, but new one doesn't.

This patch adds urldecoding and urlencoding for username, password and databaseName.