### PR TITLE
test: failing test to reproduce #318

### DIFF
--- a/test/slonik/utilities/removeCommentedOutBindings.ts
+++ b/test/slonik/utilities/removeCommentedOutBindings.ts
@@ -89,3 +89,29 @@ test('removes multiple bindings in the same comment (block comment)', (t) => {
     },
   );
 });
+
+test('does not generate undefined values for $1 appearing in a string', (t) => {
+  t.deepEqual(
+    removeCommentedOutBindings({
+      sql: 'SELECT \'$1\'',
+      values: [],
+    }),
+    {
+      sql: 'SELECT \'$1\'',
+      values: [],
+    },
+  );
+});
+
+test('does not generate undefined values for $1 appearing in a prepared statement', (t) => {
+  t.deepEqual(
+    removeCommentedOutBindings({
+      sql: 'PREPARE test_statement AS SELECT foo FROM bar WHERE baz = $1',
+      values: [],
+    }),
+    {
+      sql: 'PREPARE test_statement AS SELECT foo FROM bar WHERE baz = $1',
+      values: [],
+    },
+  );
+});


### PR DESCRIPTION
Demonstrates the problem in #318 

No solution because I don't know how to safely modify `removeCommentedOutBindings`. It's modifying both the SQL query and the `values` based on regexes.