### PR TITLE
Add functionName to callsite frames

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -2,6 +2,7 @@ declare module 'get-stack-trace' {
   export const getStackTrace: () => Promise<Array<{
     columnNumber: number,
     fileName: string,
+    functionName: string | null,
     lineNumber: number,
   }>>;
 }

--- a/src/routines/executeQuery.ts
+++ b/src/routines/executeQuery.ts
@@ -146,6 +146,7 @@ export const executeQuery = async (
         columnNumber: callSite.columnNumber,
         fileName: callSite.fileName,
         lineNumber: callSite.lineNumber,
+        functionName: callSite.functionName,
       };
     });
   }

--- a/src/routines/executeQuery.ts
+++ b/src/routines/executeQuery.ts
@@ -145,8 +145,8 @@ export const executeQuery = async (
       return {
         columnNumber: callSite.columnNumber,
         fileName: callSite.fileName,
-        lineNumber: callSite.lineNumber,
         functionName: callSite.functionName,
+        lineNumber: callSite.lineNumber,
       };
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -241,6 +241,7 @@ type CallSiteType = {
   readonly columnNumber: number,
   readonly fileName: string | null,
   readonly lineNumber: number,
+  readonly functionName: string | null,
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -240,8 +240,8 @@ export type ConnectionContextType = {
 type CallSiteType = {
   readonly columnNumber: number,
   readonly fileName: string | null,
-  readonly lineNumber: number,
   readonly functionName: string | null,
+  readonly lineNumber: number,
 };
 
 /**


### PR DESCRIPTION
An idea: it's frustrating that when there are errors in a query, the call-stacks are always full of `pg-protocol` and related sites, never much to do with the application code. `captureStackTrace` can help. Here's roughly what I want to do:

```ts
const pool = createPool('postgresql://postgres:postgres@localhost:5433/postgres', {
  captureStackTrace: true,
  interceptors: [
    {
      queryExecutionError: (context, query, error, notices) => {
        console.log({context, query, error, notices})
        if (context.stackTrace) {
          throw Object.assign(new Error(error.message), {
            stack:
              `${error.message}\n` +
              context.stackTrace
                .map(site => {
                  const location = `${site.fileName}:${site.lineNumber}:${site.columnNumber}`
                  return `    at ${site.functionName || '[unknown]'} (${location})`
                })
                .join('\n'),
            cause: error,
          })
        }
      },
    },
  ],
})
```

Basically, reverse-engineer the "real" call stack. Then when running code like this:

```ts
await pool
  .query(sql`select * from this is bad syntax`)
  .catch(e => console.log(e))
```

Before (note that everything in the call stack is useless to someone debugging):

```
syntax error at or near "is"
    at Parser.parseErrorMessage (/path/to/folder/node_modules/pg-protocol/dist/parser.js:287:98)
    at Parser.handlePacket (/path/to/folder/node_modules/pg-protocol/dist/parser.js:126:29)
    at Parser.parse (/path/to/folder/node_modules/pg-protocol/dist/parser.js:39:38)
    at Socket.<anonymous> (/path/to/folder/node_modules/pg-protocol/dist/index.js:11:42)
    at Socket.emit (events.js:376:20)
    at addChunk (internal/streams/readable.js:309:12)
    at readableAddChunk (internal/streams/readable.js:284:9)
    at Socket.Readable.push (internal/streams/readable.js:223:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:188:23) {
  length: 91,
  severity: 'ERROR',
  code: '42601',
  detail: undefined,
  hint: undefined,
  position: '20',
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  schema: undefined,
  table: undefined,
  column: undefined,
  dataType: undefined,
  constraint: undefined,
  file: 'scan.l',
  line: '1149',
  routine: 'scanner_yyerror',
  notices: []
}
```

After:

```
syntax error at or near "is"
    at executeQuery (/path/to/folder/node_modules/slonik/src/routines/executeQuery.ts:142:41)
    at query (/path/to/folder/node_modules/slonik/src/connectionMethods/query.ts:22:4)
    at query (/path/to/folder/node_modules/slonik/src/binders/bindPoolConnection.ts:150:8)
    at [unknown] (/path/to/folder/node_modules/slonik/src/binders/bindPool.ts:297:33)
    at createConnection (/path/to/folder/node_modules/slonik/src/factories/createConnection.ts:187:19)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at main (/path/to/folder/test.js:45:3) {
  cause: error: syntax error at or near "is"
      at Parser.parseErrorMessage (/path/to/folder/node_modules/pg-protocol/dist/parser.js:287:98)
      at Parser.handlePacket (/path/to/folder/node_modules/pg-protocol/dist/parser.js:126:29)
      at Parser.parse (/path/to/folder/node_modules/pg-protocol/dist/parser.js:39:38)
      at Socket.<anonymous> (/path/to/folder/node_modules/pg-protocol/dist/index.js:11:42)
      at Socket.emit (events.js:376:20)
      at addChunk (internal/streams/readable.js:309:12)
      at readableAddChunk (internal/streams/readable.js:284:9)
      at Socket.Readable.push (internal/streams/readable.js:223:10)
      at TCP.onStreamRead (internal/stream_base_commons.js:188:23) {
    length: 91,
    severity: 'ERROR',
    code: '42601',
    detail: undefined,
    hint: undefined,
    position: '20',
    internalPosition: undefined,
    internalQuery: undefined,
    where: undefined,
    schema: undefined,
    table: undefined,
    column: undefined,
    dataType: undefined,
    constraint: undefined,
    file: 'scan.l',
    line: '1149',
    routine: 'scanner_yyerror',
    notices: []
  }
}
```

Note the frame `at main (/path/to/folder/test.js:45:3)` which is where the actual query is, the part that has the typo in it and needs to change.

Most of this is possible now, but this change adds the function name so that it can be included in the call stack instead of `[unknown]`.