### PR TITLE
Docs: replace with appropriate examples in the utilities section

### DIFF
--- a/.README/UTILITIES.md
+++ b/.README/UTILITIES.md
@@ -17,7 +17,7 @@ import {
   parseDsn,
 } from 'slonik';
 
-parseDsn('postgresql://foo@localhost/bar?connect_timeout=10&application_name=baz');
+parseDsn('postgresql://foo@localhost/bar?application_name=baz');
 ```
 
 ### `stringifyDsn`
@@ -30,10 +30,17 @@ parseDsn('postgresql://foo@localhost/bar?connect_timeout=10&application_name=baz
 
 Stringifies `ConnectionOptions` to a DSN.
 
+Example:
+
 ```ts
 import {
   stringifyDsn,
 } from 'slonik';
 
-stringifyDsn('postgresql://foo@localhost/bar?connect_timeout=10&application_name=baz');
+stringifyDsn({
+  host: 'localhost',
+  username: 'foo',
+  databaseName: 'bar',
+  applicationName: 'baz',
+});
 ```

--- a/README.md
+++ b/README.md
@@ -2097,7 +2097,7 @@ import {
   parseDsn,
 } from 'slonik';
 
-parseDsn('postgresql://foo@localhost/bar?connect_timeout=10&application_name=baz');
+parseDsn('postgresql://foo@localhost/bar?application_name=baz');
 ```
 
 <a name="slonik-utilities-stringifydsn"></a>
@@ -2111,12 +2111,19 @@ parseDsn('postgresql://foo@localhost/bar?connect_timeout=10&application_name=baz
 
 Stringifies `ConnectionOptions` to a DSN.
 
+Example:
+
 ```ts
 import {
   stringifyDsn,
 } from 'slonik';
 
-stringifyDsn('postgresql://foo@localhost/bar?connect_timeout=10&application_name=baz');
+stringifyDsn({
+  host: 'localhost',
+  username: 'foo',
+  databaseName: 'bar',
+  applicationName: 'baz',
+});
 ```
 
 


### PR DESCRIPTION
Removed `connect_timeout` parameter in `parseDsn` and replaced with a correct example in `stringifyDsn`.