### PR TITLE
Close underlying QueryStream on stream.destroy()

### DIFF
--- a/src/QueryStream.ts
+++ b/src/QueryStream.ts
@@ -63,15 +63,10 @@ export class QueryStream extends Readable {
     this.cursor.submit(connection);
   }
 
-  public close (callback: Function) {
+  public _destroy (error: Error, callback: Function) {
     this._closed = true;
 
-    // eslint-disable-next-line unicorn/consistent-function-scoping
-    const close = () => {
-      this.emit('close');
-    };
-
-    this.cursor.close(callback || close);
+    this.cursor.close(callback);
   }
 
   public _read (size: number) {

--- a/test/slonik/integration/pg.ts
+++ b/test/slonik/integration/pg.ts
@@ -356,7 +356,7 @@ test('frees connection after destroying a stream', async (t) => {
   await pool.end();
 });
 
-test('does not crash after destroying a stream with an error', async (t) => {
+test('frees connection after destroying a stream with an error', async (t) => {
   const pool = await createPool(t.context.dsn);
 
   await pool.stream(sql`


### PR DESCRIPTION
Fixes #347 