### PR TITLE
feat: simplify logic behind destroying connection clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "nyc": "^15.1.0",
     "pg-native": "^3.0.0",
     "postgres": "^3.2.4",
-    "postgres-bridge": "^1.13.0",
+    "postgres-bridge": "^1.14.0",
     "semantic-release": "^18.0.1",
     "sinon": "^12.0.1",
     "ts-node": "^10.7.0",

--- a/src/factories/createConnection.ts
+++ b/src/factories/createConnection.ts
@@ -222,5 +222,7 @@ export const createConnection = async (
     terminatePoolConnection(connection);
   }
 
+  // terminatePoolConnection(boundConnection);
+
   return result;
 };

--- a/src/factories/createConnection.ts
+++ b/src/factories/createConnection.ts
@@ -44,26 +44,12 @@ type ConnectionHandlerType = (
 type PoolHandlerType = (pool: DatabasePool) => Promise<unknown>;
 
 const terminatePoolConnection = (
-  pool: PgPool,
   connection: PgPoolClient,
-  error: Error,
 ) => {
-  const poolState = getPoolState(pool);
-  const poolClientState = getPoolClientState(connection);
-
-  if (!poolClientState.terminated) {
-    poolClientState.terminated = error;
-  }
-
-  if (poolState.mock) {
-    return;
-  }
-
-  pool._remove(connection);
-  pool._pulseQueue();
+  // tells the pool to destroy this client
+  connection.release(true);
 };
 
-// eslint-disable-next-line complexity
 export const createConnection = async (
   parentLog: Logger,
   pool: PgPool,
@@ -176,7 +162,7 @@ export const createConnection = async (
       }
     }
   } catch (error) {
-    terminatePoolConnection(pool, connection, error);
+    terminatePoolConnection(connection);
 
     throw error;
   }
@@ -191,7 +177,7 @@ export const createConnection = async (
       clientConfiguration,
     );
   } catch (error) {
-    terminatePoolConnection(pool, connection, error);
+    terminatePoolConnection(connection);
 
     throw error;
   }
@@ -203,7 +189,7 @@ export const createConnection = async (
       }
     }
   } catch (error) {
-    terminatePoolConnection(pool, connection, error);
+    terminatePoolConnection(connection);
 
     throw error;
   }
@@ -233,7 +219,7 @@ export const createConnection = async (
     // `pool._remove(connection)` ensures that we create a new connection for each `pool.connect()`.
     //
     // The downside of this approach is that we cannot leverage idle connection pooling.
-    terminatePoolConnection(pool, connection, new ConnectionError('Forced connection termination (explicit connection).'));
+    terminatePoolConnection(connection);
   }
 
   return result;

--- a/src/factories/createConnection.ts
+++ b/src/factories/createConnection.ts
@@ -50,6 +50,7 @@ const terminatePoolConnection = (
   connection.release(true);
 };
 
+// eslint-disable-next-line complexity
 export const createConnection = async (
   parentLog: Logger,
   pool: PgPool,

--- a/test/slonik/binders/bindPool/connect.ts
+++ b/test/slonik/binders/bindPool/connect.ts
@@ -18,8 +18,8 @@ test('ends connection after promise is resolved (explicit connection)', async (t
   });
 
   t.is(pool.connectSpy.callCount, 1);
-  t.is(pool.releaseSpy.callCount, 0);
-  t.is(pool.removeSpy.callCount, 1);
+  t.is(pool.releaseSpy.callCount, 1);
+  t.true(pool.releaseSpy.calledWith(true));
 });
 
 test('release connection after promise is resolved (implicit connection)', async (t) => {
@@ -40,8 +40,8 @@ test('ends connection after promise is rejected', async (t) => {
   }));
 
   t.is(pool.connectSpy.callCount, 1);
-  t.is(pool.releaseSpy.callCount, 0);
-  t.is(pool.removeSpy.callCount, 1);
+  t.is(pool.releaseSpy.callCount, 1);
+  t.true(pool.releaseSpy.calledWith(true));
 });
 
 test('does not connect if `beforePoolConnection` throws an error', async (t) => {
@@ -80,8 +80,8 @@ test('ends connection if `afterPoolConnection` throws an error', async (t) => {
   }));
 
   t.is(pool.connectSpy.callCount, 1);
-  t.is(pool.releaseSpy.callCount, 0);
-  t.is(pool.removeSpy.callCount, 1);
+  t.is(pool.releaseSpy.callCount, 1);
+  t.true(pool.releaseSpy.calledWith(true));
 });
 
 test('ends connection if `beforePoolConnectionRelease` throws an error', async (t) => {
@@ -100,8 +100,8 @@ test('ends connection if `beforePoolConnectionRelease` throws an error', async (
   }));
 
   t.is(pool.connectSpy.callCount, 1);
-  t.is(pool.releaseSpy.callCount, 0);
-  t.is(pool.removeSpy.callCount, 1);
+  t.is(pool.releaseSpy.callCount, 1);
+  t.true(pool.releaseSpy.calledWith(true));
 });
 
 test('if `beforePoolConnection` returns pool object, then the returned pool object is used to create a new connection (IMPLICIT_QUERY)', async (t) => {
@@ -172,8 +172,8 @@ test('if `beforePoolConnection` returns pool object, then the returned pool obje
   });
 
   t.is(pool0.connectSpy.callCount, 1);
-  t.is(pool0.releaseSpy.callCount, 0);
-  t.is(pool0.removeSpy.callCount, 1);
+  t.is(pool0.releaseSpy.callCount, 1);
+  t.true(pool0.releaseSpy.calledWith(true));
 
   t.is(pool1.connectSpy.callCount, 0);
   t.is(pool1.releaseSpy.callCount, 0);


### PR DESCRIPTION
I cannot recall the reason for the earlier implementation, but it was either because pg-pool did not provide a method to destroy connection upon release or because I was not familiar with that functionality.