### PR TITLE
refactor: pass the entire tagged template

### DIFF
--- a/src/binders/bindPoolConnection.ts
+++ b/src/binders/bindPoolConnection.ts
@@ -31,138 +31,126 @@ export const bindPoolConnection = (
   clientConfiguration: ClientConfiguration,
 ): DatabasePoolConnection => {
   return {
-    any: (query) => {
-      assertSqlSqlToken(query);
+    any: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
 
       return any(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    anyFirst: (query) => {
-      assertSqlSqlToken(query);
+    anyFirst: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
 
       return anyFirst(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    copyFromBinary: (query, values, columnTypes) => {
-      assertSqlSqlToken(query);
+    copyFromBinary: (slonikSql, values, columnTypes) => {
+      assertSqlSqlToken(slonikSql);
 
       return copyFromBinary(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
         values,
         columnTypes,
       );
     },
-    exists: (query) => {
-      assertSqlSqlToken(query);
+    exists: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
 
       return exists(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    many: (query) => {
-      assertSqlSqlToken(query);
+    many: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
 
       return many(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    manyFirst: (query) => {
-      assertSqlSqlToken(query);
+    manyFirst: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
 
       return manyFirst(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    maybeOne: (query) => {
-      assertSqlSqlToken(query);
+    maybeOne: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
 
       return maybeOne(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    maybeOneFirst: (query) => {
-      assertSqlSqlToken(query);
+    maybeOneFirst: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
 
       return maybeOneFirst(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    one: (query) => {
-      assertSqlSqlToken(query);
+    one: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
 
       return one(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    oneFirst: (query) => {
-      assertSqlSqlToken(query);
+    oneFirst: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
 
       return oneFirst(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    query: (query) => {
-      assertSqlSqlToken(query);
+    query: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
 
       return queryMethod(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    stream: (query, streamHandler, config) => {
-      assertSqlSqlToken(query);
+    stream: (slonikSql, streamHandler, config) => {
+      assertSqlSqlToken(slonikSql);
 
       return stream(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
         streamHandler,
         undefined,
         config,

--- a/src/binders/bindTransactionConnection.ts
+++ b/src/binders/bindTransactionConnection.ts
@@ -42,136 +42,125 @@ export const bindTransactionConnection = (
   };
 
   return {
-    any: (query) => {
-      assertSqlSqlToken(query);
+    any: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
       assertTransactionDepth();
 
       return any(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    anyFirst: (query) => {
-      assertSqlSqlToken(query);
+    anyFirst: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
       assertTransactionDepth();
 
       return anyFirst(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    exists: (query) => {
-      assertSqlSqlToken(query);
+    exists: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
       assertTransactionDepth();
 
       return exists(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    many: (query) => {
-      assertSqlSqlToken(query);
+    many: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
       assertTransactionDepth();
 
       return many(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    manyFirst: (query) => {
-      assertSqlSqlToken(query);
+    manyFirst: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
       assertTransactionDepth();
 
       return manyFirst(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    maybeOne: (query) => {
-      assertSqlSqlToken(query);
+    maybeOne: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
       assertTransactionDepth();
 
       return maybeOne(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    maybeOneFirst: (query) => {
-      assertSqlSqlToken(query);
+    maybeOneFirst: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
       assertTransactionDepth();
 
       return maybeOneFirst(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    one: (query) => {
-      assertSqlSqlToken(query);
+    one: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
       assertTransactionDepth();
 
       return one(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    oneFirst: (query) => {
-      assertSqlSqlToken(query);
+    oneFirst: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
       assertTransactionDepth();
 
       return oneFirst(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    query: (query) => {
-      assertSqlSqlToken(query);
+    query: (slonikSql) => {
+      assertSqlSqlToken(slonikSql);
       assertTransactionDepth();
 
       return queryMethod(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
       );
     },
-    stream: (query, streamHandler) => {
-      assertSqlSqlToken(query);
+    stream: (slonikSql, streamHandler) => {
+      assertSqlSqlToken(slonikSql);
       assertTransactionDepth();
 
       return stream(
         parentLog,
         connection,
         clientConfiguration,
-        query.sql,
-        query.values,
+        slonikSql,
         streamHandler,
       );
     },

--- a/src/connectionMethods/any.ts
+++ b/src/connectionMethods/any.ts
@@ -11,12 +11,12 @@ import {
 /**
  * Makes a query and expects any number of results.
  */
-export const any: InternalQueryMethod = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const any: InternalQueryMethod = async (log, connection, clientConfiguration, slonikSql, inheritedQueryId) => {
   const queryId = inheritedQueryId ?? createQueryId();
 
   const {
     rows,
-  } = await query(log, connection, clientConfiguration, rawSql, values, queryId);
+  } = await query(log, connection, clientConfiguration, slonikSql, queryId);
 
   return rows;
 };

--- a/src/connectionMethods/anyFirst.ts
+++ b/src/connectionMethods/anyFirst.ts
@@ -11,10 +11,10 @@ import {
   any,
 } from './any';
 
-export const anyFirst: InternalQueryMethod = async (log, connection, clientConfigurationType, rawSql, values, inheritedQueryId) => {
+export const anyFirst: InternalQueryMethod = async (log, connection, clientConfigurationType, slonikSql, inheritedQueryId) => {
   const queryId = inheritedQueryId ?? createQueryId();
 
-  const rows = await any(log, connection, clientConfigurationType, rawSql, values, queryId);
+  const rows = await any(log, connection, clientConfigurationType, slonikSql, queryId);
 
   if (rows.length === 0) {
     return [];

--- a/src/connectionMethods/copyFromBinary.ts
+++ b/src/connectionMethods/copyFromBinary.ts
@@ -27,8 +27,7 @@ export const copyFromBinary: InternalCopyFromBinaryFunction = async (
   connectionLogger,
   connection,
   clientConfiguration,
-  rawSql,
-  boundValues,
+  slonikSql,
   tupleList,
   columnTypes,
 ) => {
@@ -38,8 +37,7 @@ export const copyFromBinary: InternalCopyFromBinaryFunction = async (
     connectionLogger,
     connection,
     clientConfiguration,
-    rawSql,
-    boundValues,
+    slonikSql,
     undefined,
     (finalConnection, finalSql) => {
       const copyFromBinaryStream = finalConnection.query(from(finalSql));

--- a/src/connectionMethods/exists.ts
+++ b/src/connectionMethods/exists.ts
@@ -3,6 +3,7 @@ import {
 } from '../errors';
 import {
   type InternalQueryMethod,
+  type TaggedTemplateLiteralInvocation,
 } from '../types';
 import {
   createQueryId,
@@ -11,12 +12,21 @@ import {
   query,
 } from './query';
 
-export const exists: InternalQueryMethod<Promise<boolean>> = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const exists: InternalQueryMethod<Promise<boolean>> = async (log, connection, clientConfiguration, slonikSql, inheritedQueryId) => {
   const queryId = inheritedQueryId ?? createQueryId();
 
   const {
     rows,
-  } = await query(log, connection, clientConfiguration, 'SELECT EXISTS(' + rawSql + ')', values, queryId);
+  } = await query(
+    log,
+    connection,
+    clientConfiguration,
+    {
+      sql: 'SELECT EXISTS(' + slonikSql.sql + ')',
+      values: slonikSql.values,
+    } as TaggedTemplateLiteralInvocation,
+    queryId,
+  );
 
   if (rows.length !== 1) {
     log.error({

--- a/src/connectionMethods/many.ts
+++ b/src/connectionMethods/many.ts
@@ -16,12 +16,12 @@ import {
  *
  * @throws NotFoundError If query returns no rows.
  */
-export const many: InternalQueryMethod = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const many: InternalQueryMethod = async (log, connection, clientConfiguration, slonikSql, inheritedQueryId) => {
   const queryId = inheritedQueryId ?? createQueryId();
 
   const {
     rows,
-  } = await query(log, connection, clientConfiguration, rawSql, values, queryId);
+  } = await query(log, connection, clientConfiguration, slonikSql, queryId);
 
   if (rows.length === 0) {
     log.error({

--- a/src/connectionMethods/manyFirst.ts
+++ b/src/connectionMethods/manyFirst.ts
@@ -11,10 +11,10 @@ import {
   many,
 } from './many';
 
-export const manyFirst: InternalQueryMethod = async (log, connection, clientConfigurationType, rawSql, values, inheritedQueryId) => {
+export const manyFirst: InternalQueryMethod = async (log, connection, clientConfigurationType, slonikSql, inheritedQueryId) => {
   const queryId = inheritedQueryId ?? createQueryId();
 
-  const rows = await many(log, connection, clientConfigurationType, rawSql, values, queryId);
+  const rows = await many(log, connection, clientConfigurationType, slonikSql, queryId);
 
   if (rows.length === 0) {
     log.error({

--- a/src/connectionMethods/maybeOne.ts
+++ b/src/connectionMethods/maybeOne.ts
@@ -16,12 +16,12 @@ import {
  *
  * @throws DataIntegrityError If query returns multiple rows.
  */
-export const maybeOne: InternalQueryMethod = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const maybeOne: InternalQueryMethod = async (log, connection, clientConfiguration, slonikSql, inheritedQueryId) => {
   const queryId = inheritedQueryId ?? createQueryId();
 
   const {
     rows,
-  } = await query(log, connection, clientConfiguration, rawSql, values, queryId);
+  } = await query(log, connection, clientConfiguration, slonikSql, queryId);
 
   if (rows.length === 0) {
     return null;

--- a/src/connectionMethods/maybeOneFirst.ts
+++ b/src/connectionMethods/maybeOneFirst.ts
@@ -17,15 +17,14 @@ import {
  *
  * @throws DataIntegrityError If query returns multiple rows.
  */
-export const maybeOneFirst: InternalQueryMethod = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const maybeOneFirst: InternalQueryMethod = async (log, connection, clientConfiguration, slonikSql, inheritedQueryId) => {
   const queryId = inheritedQueryId ?? createQueryId();
 
   const row = await maybeOne(
     log,
     connection,
     clientConfiguration,
-    rawSql,
-    values,
+    slonikSql,
     queryId,
   );
 

--- a/src/connectionMethods/one.ts
+++ b/src/connectionMethods/one.ts
@@ -18,12 +18,12 @@ import {
  * @throws NotFoundError If query returns no rows.
  * @throws DataIntegrityError If query returns multiple rows.
  */
-export const one: InternalQueryMethod = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const one: InternalQueryMethod = async (log, connection, clientConfiguration, slonikSql, inheritedQueryId) => {
   const queryId = inheritedQueryId ?? createQueryId();
 
   const {
     rows,
-  } = await query(log, connection, clientConfiguration, rawSql, values, queryId);
+  } = await query(log, connection, clientConfiguration, slonikSql, queryId);
 
   if (rows.length === 0) {
     log.error({

--- a/src/connectionMethods/oneFirst.ts
+++ b/src/connectionMethods/oneFirst.ts
@@ -18,15 +18,14 @@ import {
  * @throws NotFoundError If query returns no rows.
  * @throws DataIntegrityError If query returns multiple rows.
  */
-export const oneFirst: InternalQueryMethod = async (log, connection, clientConfiguration, rawSql, values, inheritedQueryId) => {
+export const oneFirst: InternalQueryMethod = async (log, connection, clientConfiguration, slonikSql, inheritedQueryId) => {
   const queryId = inheritedQueryId ?? createQueryId();
 
   const row = await one(
     log,
     connection,
     clientConfiguration,
-    rawSql,
-    values,
+    slonikSql,
     queryId,
   );
 

--- a/src/connectionMethods/query.ts
+++ b/src/connectionMethods/query.ts
@@ -14,16 +14,14 @@ export const query: InternalQueryMethod = async (
   connectionLogger,
   connection,
   clientConfiguration,
-  rawSql,
-  values,
+  slonikSql,
   inheritedQueryId,
 ) => {
   return await executeQuery(
     connectionLogger,
     connection,
     clientConfiguration,
-    rawSql,
-    values,
+    slonikSql,
     inheritedQueryId,
     async (finalConnection, finalSql, finalValues) => {
       const result: PgQueryResult & {notices?: Notice[], } = await finalConnection.query(

--- a/src/connectionMethods/stream.ts
+++ b/src/connectionMethods/stream.ts
@@ -11,13 +11,12 @@ import {
   type InternalStreamFunction,
 } from '../types';
 
-export const stream: InternalStreamFunction = async (connectionLogger, connection, clientConfiguration, rawSql, values, streamHandler, uid, options) => {
+export const stream: InternalStreamFunction = async (connectionLogger, connection, clientConfiguration, slonikSql, streamHandler, uid, options) => {
   return await executeQuery(
     connectionLogger,
     connection,
     clientConfiguration,
-    rawSql,
-    values,
+    slonikSql,
     undefined,
     (finalConnection, finalSql, finalValues, executionContext, actualQuery) => {
       const query = new QueryStream(finalSql, finalValues, options);

--- a/src/routines/executeQuery.ts
+++ b/src/routines/executeQuery.ts
@@ -36,6 +36,7 @@ import {
   type QueryResultRow,
   type QueryResult,
   type Query,
+  type TaggedTemplateLiteralInvocation,
 } from '../types';
 import {
   createQueryId,
@@ -121,11 +122,14 @@ export const executeQuery = async (
   connectionLogger: Logger,
   connection: PgPoolClient,
   clientConfiguration: ClientConfiguration,
-  slonikSql: string,
-  values: readonly PrimitiveValueExpression[],
+  slonikSqlRename: TaggedTemplateLiteralInvocation,
   inheritedQueryId: QueryId | undefined,
   executionRoutine: ExecutionRoutineType,
 ): Promise<QueryResult<Record<string, PrimitiveValueExpression>>> => {
+  // TODO rename
+  const slonikSql = slonikSqlRename.sql;
+  const values = slonikSqlRename.values;
+
   const poolClientState = getPoolClientState(connection);
 
   if (poolClientState.terminated) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -368,8 +368,7 @@ export type InternalQueryMethod<R = any> = (
   log: Logger,
   connection: PgPoolClient,
   clientConfiguration: ClientConfiguration,
-  sql: string,
-  values: readonly PrimitiveValueExpression[],
+  slonikSql: TaggedTemplateLiteralInvocation,
   uid?: QueryId,
 ) => R;
 
@@ -377,8 +376,7 @@ export type InternalCopyFromBinaryFunction = (
   log: Logger,
   connection: PgPoolClient,
   clientConfiguration: ClientConfiguration,
-  sql: string,
-  boundValues: readonly PrimitiveValueExpression[],
+  slonikSql: TaggedTemplateLiteralInvocation,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   tupleList: ReadonlyArray<readonly any[]>,
   columnTypes: readonly TypeNameIdentifier[],
@@ -388,8 +386,7 @@ export type InternalStreamFunction = (
   log: Logger,
   connection: PgPoolClient,
   clientConfiguration: ClientConfiguration,
-  sql: string,
-  values: readonly PrimitiveValueExpression[],
+  slonikSql: TaggedTemplateLiteralInvocation,
   streamHandler: StreamHandler,
   uid?: QueryId,
   config?: QueryStreamConfig,

--- a/test/slonik/routines/executeQuery.ts
+++ b/test/slonik/routines/executeQuery.ts
@@ -6,6 +6,9 @@ import {
 } from 'roarr';
 import * as sinon from 'sinon';
 import {
+  type TaggedTemplateLiteralInvocation,
+} from '../../../src';
+import {
   InvalidInputError,
 } from '../../../src/errors';
 import {
@@ -59,8 +62,10 @@ test('throws a descriptive error if query is empty', async (t) => {
       t.context.logger,
       t.context.connection,
       createClientConfiguration(),
-      '',
-      [],
+      {
+        sql: '',
+        values: [],
+      } as unknown as TaggedTemplateLiteralInvocation,
       'foo',
       t.context.executionRoutine,
     );
@@ -76,8 +81,10 @@ test('throws a descriptive error if the entire query is a value binding', async 
       t.context.logger,
       t.context.connection,
       createClientConfiguration(),
-      '$1',
-      [],
+      {
+        sql: '$1',
+        values: [],
+      } as unknown as TaggedTemplateLiteralInvocation,
       'foo',
       t.context.executionRoutine,
     );
@@ -109,8 +116,10 @@ test('retries an implicit query that failed due to a transaction error', async (
     t.context.logger,
     t.context.connection,
     createClientConfiguration(),
-    'SELECT 1 AS foo',
-    [],
+    {
+      sql: 'SELECT 1 AS foo',
+      values: [],
+    } as unknown as TaggedTemplateLiteralInvocation,
     'foo',
     executionRoutineStub,
   );
@@ -146,8 +155,10 @@ test('returns the thrown transaction error if the retry limit is reached', async
       ...clientConfiguration,
       queryRetryLimit: 1,
     },
-    'SELECT 1 AS foo',
-    [],
+    {
+      sql: 'SELECT 1 AS foo',
+      values: [],
+    } as unknown as TaggedTemplateLiteralInvocation,
     'foo',
     executionRoutineStub,
   ));
@@ -183,8 +194,10 @@ test('transaction errors are not handled if the function was called by a transac
       ...clientConfiguration,
       queryRetryLimit: 1,
     },
-    'SELECT 1 AS foo',
-    [],
+    {
+      sql: 'SELECT 1 AS foo',
+      values: [],
+    } as unknown as TaggedTemplateLiteralInvocation,
     'foo',
     executionRoutineStub,
   ));


### PR DESCRIPTION
This makes it easier to introduce additional properties associated with the query, such as the zod object.