### PR TITLE
feat: zod parser, non-breaking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,8 @@
         "semantic-release": "^19.0.3",
         "sinon": "^12.0.1",
         "ts-node": "^10.7.0",
-        "typescript": "^4.7.4"
+        "typescript": "^4.7.4",
+        "zod": "^3.17.10"
       },
       "engines": {
         "node": ">=10.0"
@@ -14836,6 +14837,15 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.17.10",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.10.tgz",
+      "integrity": "sha512-IHXnQYQuOOOL/XgHhgl8YjNxBHi3xX0mVcHmqsvJgcxKkEczPshoWdxqyFwsARpf41E0v9U95WUROqsHHxt0UQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -25750,6 +25760,12 @@
     "yocto-queue": {
       "version": "0.1.0",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
+    },
+    "zod": {
+      "version": "3.17.10",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.10.tgz",
+      "integrity": "sha512-IHXnQYQuOOOL/XgHhgl8YjNxBHi3xX0mVcHmqsvJgcxKkEczPshoWdxqyFwsARpf41E0v9U95WUROqsHHxt0UQ==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "semantic-release": "^19.0.3",
     "sinon": "^12.0.1",
     "ts-node": "^10.7.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "zod": "^3.17.10"
   },
   "engines": {
     "node": ">=10.0"

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,6 @@
 import ExtendableError from 'es6-error';
 import {
+  type ParserIssue,
   type SerializableValue,
 } from './types';
 
@@ -66,9 +67,9 @@ export class SchemaValidationError extends SlonikError {
 
   public row: SerializableValue;
 
-  public issues: unknown[];
+  public issues: ParserIssue[];
 
-  public constructor (sql: string, row: SerializableValue, issues: unknown[]) {
+  public constructor (sql: string, row: SerializableValue, issues: ParserIssue[]) {
     super('Query returned rows that do not conform with the schema.');
 
     this.sql = sql;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,7 @@
 import ExtendableError from 'es6-error';
+import {
+  type SerializableValue,
+} from './types';
 
 export class SlonikError extends ExtendableError {}
 
@@ -55,6 +58,22 @@ export class NotFoundError extends SlonikError {
 export class DataIntegrityError extends SlonikError {
   public constructor () {
     super('Query returns an unexpected result.');
+  }
+}
+
+export class SchemaValidationError extends SlonikError {
+  public sql: string;
+
+  public row: SerializableValue;
+
+  public issues: unknown[];
+
+  public constructor (sql: string, row: SerializableValue, issues: unknown[]) {
+    super('Query returned rows that do not conform with the schema.');
+
+    this.sql = sql;
+    this.row = row;
+    this.issues = issues;
   }
 }
 

--- a/src/factories/createSqlTag.ts
+++ b/src/factories/createSqlTag.ts
@@ -175,6 +175,17 @@ sql.literalValue = (
   };
 };
 
+sql.type = (
+  parser,
+) => {
+  return (...args) => {
+    return {
+      ...sql(...args),
+      parser,
+    };
+  };
+};
+
 sql.unnest = (
   tuples: ReadonlyArray<readonly PrimitiveValueExpression[]>,
   columnTypes: Array<[...string[], TypeNameIdentifier]> | Array<SqlSqlToken | TypeNameIdentifier>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -339,12 +339,17 @@ export type NamedAssignment = {
 };
 
 /**
- * Usually, a `zod` type
+ * Usually, a `ZodIssue` - but in theory you could construct your own, or wrap zod.
+ * Re-defined here to avoid a hard dependency on zod.
+ */
+export type ParserIssue = {code: string; path: (string | number)[]; message: string}
+/**
+ * Usually, a `zod` type.
+ * Re-defined here to avoid a hard dependency on zod.
  */
  export type Parser<T> = {
-  safeParse: (input: unknown) => { data: T, success: true, } | { error: { issues: unknown[] }, success: false, },
+  safeParse: (input: unknown) => { data: T, success: true, } | { error: { issues: ParserIssue[] }, success: false, },
 };
-
 
 // @todo may want to think how to make this extendable.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/types.ts
+++ b/src/types.ts
@@ -301,7 +301,8 @@ export type JsonSqlToken = {
   readonly value: SerializableValue,
 };
 
-export type SqlSqlToken = {
+export type SqlSqlToken<T = UserQueryResultRow> = {
+  readonly parser?: Parser<T>,
   readonly sql: string,
   readonly type: typeof tokens.SqlToken,
   readonly values: readonly PrimitiveValueExpression[],
@@ -337,6 +338,14 @@ export type NamedAssignment = {
   readonly [key: string]: ValueExpression,
 };
 
+/**
+ * Usually, a `zod` type
+ */
+ export type Parser<T> = {
+  safeParse: (input: unknown) => { data: T, success: true, } | { error: { issues: unknown[] }, success: false, },
+};
+
+
 // @todo may want to think how to make this extendable.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type UserQueryResultRow = Record<string, any>;
@@ -353,6 +362,7 @@ export type SqlTaggedTemplate<T extends UserQueryResultRow = QueryResultRow> = {
   json: (value: SerializableValue) => JsonSqlToken,
   jsonb: (value: SerializableValue) => JsonBinarySqlToken,
   literalValue: (value: string) => SqlSqlToken,
+  type: <U>(parser: Parser<U>) => (template: TemplateStringsArray, ...values: ValueExpression[]) => TaggedTemplateLiteralInvocation<U>,
   unnest: (
     // Value might be ReadonlyArray<ReadonlyArray<PrimitiveValueExpression>>,
     // or it can be infinitely nested array, e.g.

--- a/test/slonik/connectionMethods/one.ts
+++ b/test/slonik/connectionMethods/one.ts
@@ -95,6 +95,32 @@ test('describes zod object associated with the query', async (t) => {
   });
 });
 
+test('respects zod transformers', async (t) => {
+  const pool = createPool();
+
+  pool.querySpy.returns({
+    rows: [
+      {
+        foo: 'x,y',
+      },
+    ],
+  });
+
+  const zodObject = z.object({
+    foo: z.string().transform(s => s.split(',')),
+  });
+
+  const query = sql.type(zodObject)`SELECT 'x,y' as foo`;
+
+  const result = await pool.one(query);
+
+  expectTypeOf(result).toMatchTypeOf<{foo: string[], }>();
+
+  t.deepEqual(result, {
+    foo: ['x', 'y'],
+  });
+});
+
 test('throws an error if object does match the zod object shape', async (t) => {
   const pool = createPool();
 

--- a/test/slonik/connectionMethods/one.ts
+++ b/test/slonik/connectionMethods/one.ts
@@ -121,6 +121,33 @@ test('respects zod transformers', async (t) => {
   });
 });
 
+test('strips keys by default', async (t) => {
+  const pool = createPool();
+
+  pool.querySpy.returns({
+    rows: [
+      {
+        foo: 'x',
+        bar: 'y',
+      },
+    ],
+  });
+
+  const zodObject = z.object({
+    foo: z.string(),
+  });
+
+  const query = sql.type(zodObject)`SELECT 'x' as foo, 'y' as bar`;
+
+  const result = await pool.one(query);
+
+  expectTypeOf(result).toMatchTypeOf<{ foo: string }>();
+
+  t.deepEqual(result, {
+    foo: 'x',
+  });
+});
+
 test('throws an error if object does match the zod object shape', async (t) => {
   const pool = createPool();
 

--- a/test/slonik/connectionMethods/oneFirst.ts
+++ b/test/slonik/connectionMethods/oneFirst.ts
@@ -1,5 +1,13 @@
 import test from 'ava';
 import {
+  expectTypeOf,
+} from 'expect-type';
+import {
+  z,
+} from 'zod';
+import {
+  type SchemaValidationError,
+
   DataIntegrityError,
   NotFoundError,
   UnexpectedStateError,
@@ -55,7 +63,9 @@ test('throws an error if more than one row is returned', async (t) => {
     ],
   });
 
-  const error = await t.throwsAsync(pool.oneFirst(sql`SELECT 1`));
+  const query = sql`SELECT 1`;
+
+  const error = await t.throwsAsync(pool.oneFirst(query));
 
   t.true(error instanceof DataIntegrityError);
 });
@@ -75,4 +85,64 @@ test('throws an error if more than one column is returned', async (t) => {
   const error = await t.throwsAsync(pool.oneFirst(sql`SELECT 1`));
 
   t.true(error instanceof UnexpectedStateError);
+});
+
+test('describes zod object associated with the query', async (t) => {
+  const pool = createPool();
+
+  pool.querySpy.returns({
+    rows: [
+      {
+        foo: 1,
+      },
+    ],
+  });
+
+  const zodObject = z.object({
+    foo: z.number(),
+  });
+
+  const query = sql.type(zodObject)`SELECT 1`;
+
+  const result = await pool.oneFirst(query);
+
+  expectTypeOf(result).toMatchTypeOf<number>();
+
+  t.is(result, 1);
+});
+
+test('throws an error if object does match the zod object shape', async (t) => {
+  const pool = createPool();
+
+  pool.querySpy.returns({
+    rows: [
+      {
+        foo: '1',
+      },
+    ],
+  });
+
+  const zodObject = z.object({
+    foo: z.number(),
+  });
+
+  const query = sql.type(zodObject)`SELECT 1`;
+
+  const error = await t.throwsAsync<SchemaValidationError>(pool.oneFirst(query));
+
+  t.is(error?.sql, 'SELECT 1');
+  t.deepEqual(error?.row, {
+    foo: '1',
+  });
+  t.deepEqual(error?.issues, [
+    {
+      code: 'invalid_type',
+      expected: 'number',
+      message: 'Expected number, received string',
+      path: [
+        'foo',
+      ],
+      received: 'string',
+    },
+  ]);
 });

--- a/test/slonik/templateTags/sql/sql.ts
+++ b/test/slonik/templateTags/sql/sql.ts
@@ -5,6 +5,9 @@ import {
   ROARR,
 } from 'roarr';
 import {
+  z,
+} from 'zod';
+import {
   createSqlTag,
 } from '../../../../src/factories/createSqlTag';
 import {
@@ -108,4 +111,15 @@ test('the sql property is immutable', (t) => {
     // @ts-expect-error
     query.sql = 'SELECT 2';
   });
+});
+
+test('describes zod object associated with the query', (t) => {
+  const zodObject = z.object({
+    id: z.number(),
+  });
+
+  const query = sql.type(zodObject)`
+    SELECT 1 id
+  `;
+  t.is(query.parser, zodObject);
 });

--- a/test/slonik/templateTags/sql/sql.ts
+++ b/test/slonik/templateTags/sql/sql.ts
@@ -122,4 +122,10 @@ test('describes zod object associated with the query', (t) => {
     SELECT 1 id
   `;
   t.is(query.parser, zodObject);
+
+  // @ts-expect-error Accessing a private property
+  t.is(query.parser._def?.typeName, 'ZodObject');
+
+  // @ts-expect-error Accessing a private property
+  t.is(query.parser._def?.unknownKeys, 'strip');
 });

--- a/test/types.ts
+++ b/test/types.ts
@@ -165,4 +165,30 @@ export const queryMethods = async (): Promise<void> => {
   expectTypeOf(await client.maybeOneFirst(jsonbSql)).toEqualTypeOf<{ bar: number, } | null>();
   expectTypeOf(await client.manyFirst(jsonbSql)).toEqualTypeOf<ReadonlyArray<{ bar: number, }>>();
   expectTypeOf(await client.anyFirst(jsonbSql)).toEqualTypeOf<ReadonlyArray<{ bar: number, }>>();
+
+  // `interface` can behave slightly differently from `type` when it comes to type inference
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+  interface IRow {
+    foo: string | null;
+  }
+
+  const nullableSql = sql<IRow>`select 'abc' as foo`;
+
+  expectTypeOf(await client.query(nullableSql)).toEqualTypeOf<QueryResult<IRow>>();
+  expectTypeOf(await client.one(nullableSql)).toEqualTypeOf<IRow>();
+  expectTypeOf(await client.maybeOne(nullableSql)).toEqualTypeOf<IRow | null>();
+  expectTypeOf(await client.any(nullableSql)).toEqualTypeOf<readonly IRow[]>();
+  expectTypeOf(await client.many(nullableSql)).toEqualTypeOf<readonly IRow[]>();
+  expectTypeOf(await client.oneFirst(nullableSql)).toEqualTypeOf<string | null>();
+  expectTypeOf(await client.maybeOneFirst(nullableSql)).toEqualTypeOf<string | null>();
+  expectTypeOf(await client.manyFirst(nullableSql)).toEqualTypeOf<ReadonlyArray<string | null>>();
+  expectTypeOf(await client.anyFirst(nullableSql)).toEqualTypeOf<ReadonlyArray<string | null>>();
+
+  const FooBarRow = z.object({
+    x: z.string(),
+    y: z.number(),
+  });
+
+  expectTypeOf(await client.one(sql.type(FooBarRow)`select 'x' x, 123 y`)).toEqualTypeOf<{ x: string, y: number, }>();
+  expectTypeOf(await client.any(sql.type(FooBarRow)`select 'x' x, 123 y`)).toEqualTypeOf<ReadonlyArray<{ x: string, y: number, }>>();
 };

--- a/test/types.ts
+++ b/test/types.ts
@@ -7,6 +7,9 @@ import {
   expectTypeOf,
 } from 'expect-type';
 import {
+  z,
+} from 'zod';
+import {
   createPool,
   sql,
 } from '../src';
@@ -148,4 +151,12 @@ export const queryMethods = async (): Promise<void> => {
   expectTypeOf(await client.maybeOneFirst(nullableSql)).toEqualTypeOf<string | null>();
   expectTypeOf(await client.manyFirst(nullableSql)).toEqualTypeOf<ReadonlyArray<string | null>>();
   expectTypeOf(await client.anyFirst(nullableSql)).toEqualTypeOf<ReadonlyArray<string | null>>();
+
+  const FooBarRow = z.object({
+    x: z.string(),
+    y: z.number(),
+  });
+
+  expectTypeOf(await client.one(sql.type(FooBarRow)`select 'x' x, 123 y`)).toEqualTypeOf<{ x: string, y: number, }>();
+  expectTypeOf(await client.any(sql.type(FooBarRow)`select 'x' x, 123 y`)).toEqualTypeOf<ReadonlyArray<{ x: string, y: number, }>>();
 };

--- a/test/types.ts
+++ b/test/types.ts
@@ -3,7 +3,7 @@
  * a type-level tests to ensure the typings don't regress.
  */
 
-import {
+ import {
   expectTypeOf,
 } from 'expect-type';
 import {
@@ -17,6 +17,11 @@ import {
   type PrimitiveValueExpression,
   type QueryResult,
 } from '../src/types';
+
+const ZodRow = z.object({
+  bar: z.boolean(),
+  foo: z.string(),
+});
 
 export const queryMethods = async (): Promise<void> => {
   const client = createPool('');
@@ -36,6 +41,9 @@ export const queryMethods = async (): Promise<void> => {
   const anyTypedQuery = await client.any(sql<Row>``);
   expectTypeOf(anyTypedQuery).toEqualTypeOf<readonly Row[]>();
 
+  const anyZodTypedQuery = await client.any(sql.type(ZodRow)``);
+  expectTypeOf(anyZodTypedQuery).toEqualTypeOf<readonly Row[]>();
+
   // anyFirst
   const anyFirst = await client.anyFirst(sql``);
   expectTypeOf(anyFirst).toEqualTypeOf<readonly PrimitiveValueExpression[]>();
@@ -45,6 +53,9 @@ export const queryMethods = async (): Promise<void> => {
 
   const anyFirstTypedQuery = await client.anyFirst(sql<Row>``);
   expectTypeOf(anyFirstTypedQuery).toEqualTypeOf<ReadonlyArray<boolean | string>>();
+
+  const anyFirstZodTypedQuery = await client.anyFirst(sql.type(ZodRow)``);
+  expectTypeOf(anyFirstZodTypedQuery).toEqualTypeOf<ReadonlyArray<boolean | string>>();
 
   // many
   const many = await client.many(sql``);
@@ -56,6 +67,9 @@ export const queryMethods = async (): Promise<void> => {
   const manyTypedQuery = await client.many(sql<Row>``);
   expectTypeOf(manyTypedQuery).toEqualTypeOf<readonly Row[]>();
 
+  const manyZodTypedQuery = await client.many(sql.type(ZodRow)``);
+  expectTypeOf(manyZodTypedQuery).toEqualTypeOf<readonly Row[]>();
+
   // manyFirst
   const manyFirst = await client.manyFirst(sql``);
   expectTypeOf(manyFirst).toEqualTypeOf<readonly PrimitiveValueExpression[]>();
@@ -65,6 +79,9 @@ export const queryMethods = async (): Promise<void> => {
 
   const manyFirstTypedQuery = await client.manyFirst(sql<Row>``);
   expectTypeOf(manyFirstTypedQuery).toEqualTypeOf<ReadonlyArray<boolean | string>>();
+
+  const manyFirstZodTypedQuery = await client.manyFirst(sql.type(ZodRow)``);
+  expectTypeOf(manyFirstZodTypedQuery).toEqualTypeOf<ReadonlyArray<boolean | string>>();
 
   // maybeOne
   const maybeOne = await client.maybeOne(sql``);
@@ -76,6 +93,9 @@ export const queryMethods = async (): Promise<void> => {
   const maybeOneTypedQuery = await client.maybeOne(sql<Row>``);
   expectTypeOf(maybeOneTypedQuery).toEqualTypeOf<Row | null>();
 
+  const maybeOneZodTypedQuery = await client.maybeOne(sql.type(ZodRow)``);
+  expectTypeOf(maybeOneZodTypedQuery).toEqualTypeOf<Row | null>();
+
   // maybeOneFirst
   const maybeOneFirst = await client.maybeOneFirst(sql``);
   expectTypeOf(maybeOneFirst).toEqualTypeOf<PrimitiveValueExpression>();
@@ -85,6 +105,9 @@ export const queryMethods = async (): Promise<void> => {
 
   const maybeOneFirstTypedQuery = await client.maybeOneFirst(sql<Row>``);
   expectTypeOf(maybeOneFirstTypedQuery).toEqualTypeOf<boolean | string | null>();
+
+  const maybeOneFirstZodTypedQuery = await client.maybeOneFirst(sql.type(ZodRow)``);
+  expectTypeOf(maybeOneFirstZodTypedQuery).toEqualTypeOf<boolean | string | null>();
 
   // one
   const one = await client.one(sql``);
@@ -96,6 +119,9 @@ export const queryMethods = async (): Promise<void> => {
   const oneTypedQuery = await client.one(sql<Row>``);
   expectTypeOf(oneTypedQuery).toEqualTypeOf<Row>();
 
+  const oneZodTypedQuery = await client.one(sql.type(ZodRow)``);
+  expectTypeOf(oneZodTypedQuery).toEqualTypeOf<Row>();
+
   // oneFirst
   const oneFirst = await client.oneFirst(sql``);
   expectTypeOf(oneFirst).toEqualTypeOf<PrimitiveValueExpression>();
@@ -106,6 +132,9 @@ export const queryMethods = async (): Promise<void> => {
   const oneFirstTypedQuery = await client.oneFirst(sql<Row>``);
   expectTypeOf(oneFirstTypedQuery).toEqualTypeOf<boolean | string>();
 
+  const oneFirstZodTypedQuery = await client.oneFirst(sql.type(ZodRow)``);
+  expectTypeOf(oneFirstZodTypedQuery).toEqualTypeOf<boolean | string>();
+
   // query
   const query = await client.query(sql``);
   expectTypeOf(query).toMatchTypeOf<QueryResult<Record<string, PrimitiveValueExpression>>>();
@@ -115,6 +144,9 @@ export const queryMethods = async (): Promise<void> => {
 
   const queryTypedQuery = await client.query(sql<Row>``);
   expectTypeOf(queryTypedQuery).toMatchTypeOf<{ rows: readonly Row[], }>();
+
+  const queryZodTypedQuery = await client.query(sql.type(ZodRow)``);
+  expectTypeOf(queryZodTypedQuery).toMatchTypeOf<{ rows: readonly Row[], }>();
 
   type RowWithJSONB = {
     foo: {
@@ -133,30 +165,4 @@ export const queryMethods = async (): Promise<void> => {
   expectTypeOf(await client.maybeOneFirst(jsonbSql)).toEqualTypeOf<{ bar: number, } | null>();
   expectTypeOf(await client.manyFirst(jsonbSql)).toEqualTypeOf<ReadonlyArray<{ bar: number, }>>();
   expectTypeOf(await client.anyFirst(jsonbSql)).toEqualTypeOf<ReadonlyArray<{ bar: number, }>>();
-
-  // `interface` can behave slightly differently from `type` when it comes to type inference
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  interface IRow {
-    foo: string | null;
-  }
-
-  const nullableSql = sql<IRow>`select 'abc' as foo`;
-
-  expectTypeOf(await client.query(nullableSql)).toEqualTypeOf<QueryResult<IRow>>();
-  expectTypeOf(await client.one(nullableSql)).toEqualTypeOf<IRow>();
-  expectTypeOf(await client.maybeOne(nullableSql)).toEqualTypeOf<IRow | null>();
-  expectTypeOf(await client.any(nullableSql)).toEqualTypeOf<readonly IRow[]>();
-  expectTypeOf(await client.many(nullableSql)).toEqualTypeOf<readonly IRow[]>();
-  expectTypeOf(await client.oneFirst(nullableSql)).toEqualTypeOf<string | null>();
-  expectTypeOf(await client.maybeOneFirst(nullableSql)).toEqualTypeOf<string | null>();
-  expectTypeOf(await client.manyFirst(nullableSql)).toEqualTypeOf<ReadonlyArray<string | null>>();
-  expectTypeOf(await client.anyFirst(nullableSql)).toEqualTypeOf<ReadonlyArray<string | null>>();
-
-  const FooBarRow = z.object({
-    x: z.string(),
-    y: z.number(),
-  });
-
-  expectTypeOf(await client.one(sql.type(FooBarRow)`select 'x' x, 123 y`)).toEqualTypeOf<{ x: string, y: number, }>();
-  expectTypeOf(await client.any(sql.type(FooBarRow)`select 'x' x, 123 y`)).toEqualTypeOf<ReadonlyArray<{ x: string, y: number, }>>();
 };


### PR DESCRIPTION
This is a fully backwards-compatible, non-breaking iteration on #369 

Fixes #364 (although @gajus I think the discussion on #364 should be resolved before merging, and I'd be interested to get @janpaepke's take on this too - if you'd like to integrate this into slonik-typegen, we are the two people to get on board!)

Essentially, this adds a `parser` property to the `SqlSqlToken` type - which instructs slonik to parse the query result rows before returning them. There's a _bias_ towards zod, and in docs zod should be mentioned as the only type parsing solution that will be officially supported, but there's no reason to leak Zod's abstractions into slonik explicitly.

All tests from #369 have been included here and are passing, and the tests that were deleted in #369 have been restored and are also passing - meaning this is a backwards compatible change.

The one exception to this is that `.strict()` is no longer called internally - though of course it can be called by the creator of the zod object - and one of the tests is updated to reflect this. See https://github.com/gajus/slonik/pull/369/files#r938576111

https://github.com/gajus/slonik/pull/369/files#r938624301 is still an issue, I will add a failing test to prove this and (hopefully) a fix too.