### PR TITLE
Adopt MixedRow

### DIFF
--- a/.README/RUNTIME_VALIDATION.md
+++ b/.README/RUNTIME_VALIDATION.md
@@ -107,9 +107,9 @@ You can infer the TypeScript type of the query result. There are couple of ways 
 // Infer using z.infer<typeof yourSchema>
 // https://github.com/colinhacks/zod#type-inference
 type Person = z.infer<typeof personObject>;
-// from sql tagged template `zodObject` property
+// from sql tagged template `parser` property
 type Person = z.infer<
-  personQuery.zodObject
+  personQuery.parser
 >;
 ```
 

--- a/README.md
+++ b/README.md
@@ -1322,9 +1322,9 @@ You can infer the TypeScript type of the query result. There are couple of ways 
 // Infer using z.infer<typeof yourSchema>
 // https://github.com/colinhacks/zod#type-inference
 type Person = z.infer<typeof personObject>;
-// from sql tagged template `zodObject` property
+// from sql tagged template `parser` property
 type Person = z.infer<
-  personQuery.zodObject
+  personQuery.parser
 >;
 ```
 

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -2,7 +2,10 @@ import {
   type SqlSqlToken,
 } from './types';
 
-export const assertSqlSqlToken = (subject: SqlSqlToken | null): void => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnySqlSqlToken = SqlSqlToken<any>;
+
+export const assertSqlSqlToken = (subject: AnySqlSqlToken | null): void => {
   if (typeof subject !== 'object' || subject === null || subject.type !== 'SLONIK_TOKEN_SQL') {
     throw new TypeError('Query must be constructed using `sql` tagged template literal.');
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,8 @@
 import ExtendableError from 'es6-error';
 import {
-  type ParserIssue,
+  type ZodIssue,
+} from 'zod';
+import {
   type SerializableValue,
 } from './types';
 
@@ -67,9 +69,9 @@ export class SchemaValidationError extends SlonikError {
 
   public row: SerializableValue;
 
-  public issues: ParserIssue[];
+  public issues: ZodIssue[];
 
-  public constructor (sql: string, row: SerializableValue, issues: ParserIssue[]) {
+  public constructor (sql: string, row: SerializableValue, issues: ZodIssue[]) {
     super('Query returned rows that do not conform with the schema.');
 
     this.sql = sql;

--- a/src/factories/createSqlTag.ts
+++ b/src/factories/createSqlTag.ts
@@ -212,16 +212,10 @@ sql.timestamp = (
 sql.type = (
   parser,
 ) => {
-  let strictParser = parser;
-
-  if (parser._def.unknownKeys === 'strip') {
-    strictParser = parser.strict();
-  }
-
   return (...args) => {
     return {
       ...sql(...args),
-      parser: strictParser,
+      parser,
     };
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ export {
   InvalidInputError,
   NotFoundError,
   NotNullIntegrityConstraintViolationError,
+  SchemaValidationError,
   SlonikError,
   StatementCancelledError,
   StatementTimeoutError,

--- a/src/routines/executeQuery.ts
+++ b/src/routines/executeQuery.ts
@@ -9,6 +9,9 @@ import {
   serializeError,
 } from 'serialize-error';
 import {
+  type ZodTypeAny,
+} from 'zod';
+import {
   TRANSACTION_ROLLBACK_ERROR_PREFIX,
 } from '../constants';
 import {
@@ -17,29 +20,28 @@ import {
   ForeignKeyIntegrityConstraintViolationError,
   InvalidInputError,
   NotNullIntegrityConstraintViolationError,
+  SchemaValidationError,
   StatementCancelledError,
   StatementTimeoutError,
+  TupleMovedToAnotherPartitionError,
   UnexpectedStateError,
   UniqueIntegrityConstraintViolationError,
-  TupleMovedToAnotherPartitionError,
-  SchemaValidationError,
 } from '../errors';
 import {
   getPoolClientState,
 } from '../state';
 import {
-  type Interceptor,
   type ClientConfiguration,
+  type Interceptor,
   type Logger,
   type Notice,
   type PrimitiveValueExpression,
+  type Query,
   type QueryContext,
   type QueryId,
-  type QueryResultRow,
   type QueryResult,
-  type Query,
+  type QueryResultRow,
   type TaggedTemplateLiteralInvocation,
-  type Parser,
 } from '../types';
 import {
   createQueryId,
@@ -62,7 +64,7 @@ type TransactionQuery = {
   readonly values: readonly PrimitiveValueExpression[],
 };
 
-const createParseInterceptor = (parser: Parser<unknown>): Interceptor => {
+const createParseInterceptor = (parser: ZodTypeAny): Interceptor => {
   return {
     transformRow: (executionContext, actualQuery, row) => {
       const {

--- a/src/types.ts
+++ b/src/types.ts
@@ -367,16 +367,6 @@ export type NamedAssignment = {
 };
 
 /**
- * Usually, a `ZodIssue` - but in theory you could construct your own, or wrap zod.
- * Re-defined here to avoid a hard dependency on zod.
- */
-export type ParserIssue = {
-  code: string,
-  message: string,
-  path: Array<number | string>,
-};
-
-/**
  * Usually, a `zod` type.
  * Re-defined here to avoid a hard dependency on zod.
  */

--- a/test/slonik/connectionMethods/one.ts
+++ b/test/slonik/connectionMethods/one.ts
@@ -161,31 +161,3 @@ test('throws an error if property type does not conform to zod object (invalid_t
   t.is(error.issues.length, 1);
   t.is(error.issues[0]?.code, 'invalid_type');
 });
-
-test('throws an error if result includes unknown property (unrecognized_keys)', async (t) => {
-  const pool = await createPool();
-
-  pool.querySpy.returns({
-    rows: [
-      {
-        bar: 1,
-        foo: 1,
-      },
-    ],
-  });
-
-  const zodObject = z.object({
-    foo: z.number(),
-  });
-
-  const query = sql.type(zodObject)`SELECT 1`;
-
-  const error = await t.throwsAsync<SchemaValidationError>(pool.one(query));
-
-  if (!error) {
-    throw new Error('Expected SchemaValidationError');
-  }
-
-  t.is(error.issues.length, 1);
-  t.is(error.issues[0]?.code, 'unrecognized_keys');
-});

--- a/test/slonik/templateTags/sql/sql.ts
+++ b/test/slonik/templateTags/sql/sql.ts
@@ -122,12 +122,8 @@ test('describes zod object associated with the query', (t) => {
     SELECT 1 id
   `;
 
-  // These are not equal because Slonik applies .strict() on the object it receives.
-  // t.is(query.zodObject, zodObject);
+  t.is(query.parser, zodObject);
 
   // @ts-expect-error Accessing a private property
   t.is(query.parser._def?.typeName, 'ZodObject');
-
-  // @ts-expect-error Accessing a private property
-  t.is(query.parser._def?.unknownKeys, 'strict');
 });

--- a/test/types.ts
+++ b/test/types.ts
@@ -31,6 +31,10 @@ export const queryMethods = async (): Promise<void> => {
     foo: string,
   };
 
+  // parser
+  const parser = sql.type(ZodRow)``.parser;
+  expectTypeOf(parser).toEqualTypeOf<typeof ZodRow>();
+
   // any
   const any = await client.any(sql``);
   expectTypeOf(any).toEqualTypeOf<ReadonlyArray<Record<string, PrimitiveValueExpression>>>();

--- a/test/types.ts
+++ b/test/types.ts
@@ -148,42 +148,6 @@ export const queryMethods = async (): Promise<void> => {
   const queryZodTypedQuery = await client.query(sql.type(ZodRow)``);
   expectTypeOf(queryZodTypedQuery).toMatchTypeOf<{ rows: readonly Row[], }>();
 
-  type RowWithJSONB = {
-    foo: {
-      bar: number,
-    },
-  };
-
-  const jsonbSql = sql<RowWithJSONB>`select '{"bar": 123}'::jsonb as foo`;
-
-  expectTypeOf(await client.query(jsonbSql)).toEqualTypeOf<QueryResult<RowWithJSONB>>();
-  expectTypeOf(await client.one(jsonbSql)).toEqualTypeOf<RowWithJSONB>();
-  expectTypeOf(await client.maybeOne(jsonbSql)).toEqualTypeOf<RowWithJSONB | null>();
-  expectTypeOf(await client.any(jsonbSql)).toEqualTypeOf<readonly RowWithJSONB[]>();
-  expectTypeOf(await client.many(jsonbSql)).toEqualTypeOf<readonly RowWithJSONB[]>();
-  expectTypeOf(await client.oneFirst(jsonbSql)).toEqualTypeOf<{ bar: number, }>();
-  expectTypeOf(await client.maybeOneFirst(jsonbSql)).toEqualTypeOf<{ bar: number, } | null>();
-  expectTypeOf(await client.manyFirst(jsonbSql)).toEqualTypeOf<ReadonlyArray<{ bar: number, }>>();
-  expectTypeOf(await client.anyFirst(jsonbSql)).toEqualTypeOf<ReadonlyArray<{ bar: number, }>>();
-
-  // `interface` can behave slightly differently from `type` when it comes to type inference
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-  interface IRow {
-    foo: string | null;
-  }
-
-  const nullableSql = sql<IRow>`select 'abc' as foo`;
-
-  expectTypeOf(await client.query(nullableSql)).toEqualTypeOf<QueryResult<IRow>>();
-  expectTypeOf(await client.one(nullableSql)).toEqualTypeOf<IRow>();
-  expectTypeOf(await client.maybeOne(nullableSql)).toEqualTypeOf<IRow | null>();
-  expectTypeOf(await client.any(nullableSql)).toEqualTypeOf<readonly IRow[]>();
-  expectTypeOf(await client.many(nullableSql)).toEqualTypeOf<readonly IRow[]>();
-  expectTypeOf(await client.oneFirst(nullableSql)).toEqualTypeOf<string | null>();
-  expectTypeOf(await client.maybeOneFirst(nullableSql)).toEqualTypeOf<string | null>();
-  expectTypeOf(await client.manyFirst(nullableSql)).toEqualTypeOf<ReadonlyArray<string | null>>();
-  expectTypeOf(await client.anyFirst(nullableSql)).toEqualTypeOf<ReadonlyArray<string | null>>();
-
   const FooBarRow = z.object({
     x: z.string(),
     y: z.number(),


### PR DESCRIPTION
BREAKING CHANGE:

* drops `ParserIssue` and `Parser<T>`, which were Zod-like types in favor of using Zod
* drops `.strict()`
* drops the ability to hint return type using an arbitrary object (use `sql.type` instead)
* drops the ability to hint return type using interfaces (use `sql.type` instead)
* exports `SchemaValidationError`
* fixes #398 
* fixes #397 

Context around the changes:

As we rolled out `sql.type` across our repositories in contra.com, it became clear that every use of `sql<T>` is an anti-pattern. Furthermore, the earlier implementation meant that we could not fully leverage the power of [Zod](https://github.com/colinhacks/zod) to extend and manipulate result types/shape (see #398 and #397). As such, this release is a stepping stone towards abandoning `sql<T>` in favor of `sql.type` – the next major release is most likely not going to support `sql<T>` and will instead double down on deeper Zod integration.

While this change might not be ideal for everyone, esp. if you have no desire to use Zod, based on my experience, I firmly believe that this is the best way forward to create the safest client for PostgreSQL.

The next release most likely to include these changes:

* `sql` will get renamed to `sql.fragment` – to separate query fragments from top-level queries.
* `sql` alone won't be available.
* `sql.fragment` is not going to be a valid input to query methods.
* `sql.type` will be the expected input of all query methods.
* `sql.unsafe<T>` is going to be added to address edge cases

CC @danielrearden @Boeing787 @mmkal 