### PR TITLE
Allow URL encoded host in parseDSN

### DIFF
--- a/src/utilities/parseDsn.ts
+++ b/src/utilities/parseDsn.ts
@@ -22,7 +22,7 @@ export const parseDsn = (dsn: string): ConnectionOptions => {
   const connectionOptions: ConnectionOptions = {};
 
   if (url.host) {
-    connectionOptions.host = url.hostname;
+    connectionOptions.host = decodeURIComponent(url.hostname);
   }
 
   if (url.port) {

--- a/test/slonik/utilities/parseDsn.ts
+++ b/test/slonik/utilities/parseDsn.ts
@@ -41,3 +41,9 @@ test('postgresql://fo%2Fo:b%2Far@localhost/ba%2Fz', testParse, {
   password: 'b/ar',
   username: 'fo/o',
 });
+test('postgresql://db_user:db_password@%2Fcloudsql%2Fproject-id%3Aregion-id1%3Acloudsqlinstance-name/dbname', testParse, {
+  databaseName: 'dbname',
+  host: '/cloudsql/project-id:region-id1:cloudsqlinstance-name',
+  password: 'db_password',
+  username: 'db_user',
+});


### PR DESCRIPTION
This PR allows the [connection string host to be url encoded](https://stackoverflow.com/questions/27037990/connecting-to-postgres-via-database-url-and-unix-socket-in-rails), which is needed for Google Cloud run to connect to the UNIX socket.

When connecting to Google Cloud SQL from Google Cloud Run, the default and recommended way to is to use a provided UNIX socket located at `/cloudsql/<project-id>:<region-name>:<sql-instance>`. However, to connect to that socket, the host must be provided as a URL-encoded string like `%2Fcloudsql%2F<project-id>%3A<region-name>%3Ar<sql-instance>`. Before [`slonik@25.1.0`](https://github.com/gajus/slonik/compare/v25.0.0...v25.1.0#diff-2b0be5180a88e7bd8b976003ef86aaa905781e76c629013b0b4235c0d15e6b6eR15), this worked properly because the connection URI was passed directly to `pg`. However, the new `parseDSN` util no longer url-decodes the host before passing it in to `pg`, meaning that these url-encoded sockets will stay encoded and cannot be understood by pg, resulting in an "Address Not Found" warning.

To fix this, this PR calls `decodeURICompenent` on the hostname before it is assigned to `host`. This should not cause any issues with existing urls that had no url-unsafe characters, and will allow users of GCP to connect from cloud run to cloud sql without needing to do additional setup to [connect via TCP](https://stackoverflow.com/questions/67247624/how-do-i-connect-to-google-cloud-sql-from-google-cloud-run-via-tcp/67253173#67253173).

I have tested this in a live Google Cloud Run instance and it works great! @gajus Please let me know if I'm missing anything here.