### PR TITLE
pool: don't allow connection re-use after stream()

### DIFF
--- a/src/QueryStream.ts
+++ b/src/QueryStream.ts
@@ -60,6 +60,7 @@ export class QueryStream extends Readable {
   }
 
   public submit (connection: Object) {
+    connection._usedForStream = true;
     this.cursor.submit(connection);
   }
 

--- a/src/factories/createConnection.ts
+++ b/src/factories/createConnection.ts
@@ -206,7 +206,11 @@ export const createConnection = async (
 
   destroyBoundConnection(boundConnection);
 
-  connection.release();
+  if(connection?.connection?._usedForStream) {
+    connection.release(true);
+  } else {
+    connection.release();
+  }
 
   return result;
 };

--- a/src/factories/createConnection.ts
+++ b/src/factories/createConnection.ts
@@ -206,7 +206,7 @@ export const createConnection = async (
 
   destroyBoundConnection(boundConnection);
 
-  if(connection?.connection?._usedForStream) {
+  if (connection?.connection?._usedForStream) {
     connection.release(true);
   } else {
     connection.release();


### PR DESCRIPTION
Hack to improve behaviour around https://github.com/gajus/slonik/issues/418

Workaround for https://github.com/brianc/node-postgres/issues/1674

Should be more robust that #419