### PR TITLE
eslint: enable cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   "scripts": {
     "build": "rm -fr ./dist && tsc",
     "create-readme": "gitdown ./.README/README.md --output-file ./README.md",
-    "lint": "eslint ./src ./test && tsc --noEmit",
+    "lint": "eslint --cache ./src ./test && tsc --noEmit",
     "test": "nyc ava --verbose --serial"
   },
   "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
For me this decreases `eslint` execution time from 20-30 seconds to < 2 seconds (after the first run), and would make working on contributions a bit easier.