### PR TITLE
Fix createSqlTag typing

### DIFF
--- a/src/factories/createSqlTag.ts
+++ b/src/factories/createSqlTag.ts
@@ -109,7 +109,7 @@ const createFragment = (
 };
 
 export const createSqlTag = <
-  K extends keyof Z,
+  K extends PropertyKey,
   P extends ZodTypeAny,
   Z extends Record<K, P>
 >(configuration: {


### PR DESCRIPTION
This is my attempt at fixing typing for `createSqlTag()`. See #432 for the bug I'm attempting to fix with this.

The current definition leaves the type of the key of the `typeAliases` object too wide by default, making it unknown and thus unusable as a Record key. This leads to a TypeScript compilation error. This pull request makes the key type extend `PropertyKey` instead making only valid Record key types assignable as the key type.