### PR TITLE
feat: use stringify strict mode

### DIFF
--- a/src/utilities/safeStringify.ts
+++ b/src/utilities/safeStringify.ts
@@ -1,4 +1,10 @@
-import stringify from 'safe-stable-stringify';
+import { configure } from 'safe-stable-stringify';
+
+const stringify = configure({
+  strict: true,
+  circularValue: '[Circular]',
+  bigint: true
+});
 
 export const safeStringify = (
   subject: unknown,


### PR DESCRIPTION
This mode makes sure functions, NaN, Symbols, Infinity and other values that can not be represented in JSON throw an appropriate error.

There are still cases left where the result may be undefined, such as when a replacer or toJSON function is used and that function returns undefined.

Refs: https://github.com/BridgeAR/safe-stable-stringify/issues/40

@gajus does this resolve the mentioned issue?