### PR TITLE
Do not generate TypeScript declarations (and link to TypeScript source instead)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
     "promise",
     "types"
   ],
+  "files": [
+    "src",
+    "dist"
+  ],
   "license": "BSD-3-Clause",
   "main": "./dist/index.js",
   "name": "slonik",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,6 @@
     "lint": "eslint --cache ./src ./test && tsc --noEmit",
     "test": "nyc ava --verbose --serial"
   },
-  "types": "./dist/index.d.ts",
+  "types": "./src/index.ts",
   "version": "0.0.0-development"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "declaration": true,
+    "declaration": false,
     "esModuleInterop": true,
+    "sourceMap": true,
     "module": "commonjs",
     "lib": [
       "es2021"


### PR DESCRIPTION
I just realized that there is no good reason (as far as I can tell) to be generating declarations in TypeScript project – you can just link the source code. The benefit of this approach is that if you click on 'slonik' package in your IDE, it will take you directly to `src` rather than a generated `.d.ts` file.

Maybe someone will educate me on the reason why declaration are even necessary, but for now it appears that _not_ generating declarations should be preferred as it achieves better DX.

Just adopted the same pattern for [Turbowatch](https://github.com/gajus/turbowatch) and it appears to produce the desired DX.