### PR TITLE
Add support for infinity values to timestamp parsers

### DIFF
--- a/src/factories/typeParsers/createTimestampTypeParser.ts
+++ b/src/factories/typeParsers/createTimestampTypeParser.ts
@@ -1,6 +1,14 @@
 import { type TypeParser } from '../../types';
 
 const timestampParser = (value: string | null) => {
+  if (value === 'infinity') {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  if (value === '-infinity') {
+    return Number.NEGATIVE_INFINITY;
+  }
+
   return value === null ? value : Date.parse(value + ' UTC');
 };
 

--- a/src/factories/typeParsers/createTimestampWithTimeZoneTypeParser.ts
+++ b/src/factories/typeParsers/createTimestampWithTimeZoneTypeParser.ts
@@ -1,6 +1,14 @@
 import { type TypeParser } from '../../types';
 
 const timestampParser = (value: string | null) => {
+  if (value === 'infinity') {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  if (value === '-infinity') {
+    return Number.NEGATIVE_INFINITY;
+  }
+
   return value === null ? value : Date.parse(value);
 };
 


### PR DESCRIPTION
I found it difficult working with `infinite` values in typescript in the timestamp field. This PR adds support for when the timestamp value is infinity.

Current implementation returns `NaN`, which is not the correct value for the timestamp.