### PR TITLE
Make row transforms async

### DIFF
--- a/.README/INTERCEPTORS.md
+++ b/.README/INTERCEPTORS.md
@@ -54,7 +54,7 @@ type Interceptor = {
   beforeTransformQuery?: (
     queryContext: QueryContext,
     query: Query
-  ) => Promise<null>,
+  ) => MaybePromise<null>,
   queryExecutionError?: (
     queryContext: QueryContext,
     query: Query,
@@ -69,7 +69,7 @@ type Interceptor = {
     query: Query,
     row: QueryResultRow,
     fields: Field[],
-  ) => QueryResultRow
+  ) => MaybePromise<QueryResultRow>
 };
 ```
 

--- a/.README/RUNTIME_VALIDATION.md
+++ b/.README/RUNTIME_VALIDATION.md
@@ -4,8 +4,8 @@ Slonik integrates [zod](https://github.com/colinhacks/zod) to provide runtime qu
 
 Validating queries requires to:
 
-1. Define a Zod [object](https://github.com/colinhacks/zod#objects) and passing it to `sql.type` tagged template (see below)
-1. Add a [result parser interceptor](#result-parser-interceptor)
+1. Add a [result parser interceptor](#result-parser-interceptor) during slonik initiialization
+1. For every query define a Zod [object](https://github.com/colinhacks/zod#objects) and pass it to `sql.type` tagged template ([see below](#example-use-of-sqltype))
 
 ### Motivation
 
@@ -16,6 +16,59 @@ The problem is that once you deploy the application, the database schema might c
 In contrast, by using runtime checks, you can ensure that the contract between your codebase and the database is always respected. If there is a breaking change, the application fails with a loud error that is easy to debug.
 
 By using `zod`, we get the best of both worlds: type safety and runtime checks.
+
+### Result parser interceptor
+
+Slonik works without the interceptor, but it doesn't validate the query results. To validate results, you must implement an interceptor that parses the results.
+
+For context, when Zod parsing was first introduced to Slonik, it was enabled for all queries by default. However, I eventually realized that the baked-in implementation is not going to suit everyone's needs. For this reason, I decided to take out the built-in interceptor in favor of providing examples for common use cases. What follows is based on the original default implementation.
+
+```ts
+import {
+  type Interceptor,
+  type QueryResultRow,
+  SchemaValidationError,
+} from "slonik";
+
+const createResultParserInterceptor = (): Interceptor => {
+  return {
+    // If you are not going to transform results using Zod, then you should use `afterQueryExecution` instead.
+    // Future versions of Zod will provide a more efficient parser when parsing without transformations.
+    // You can even combine the two – use `afterQueryExecution` to validate results, and (conditionally)
+    // transform results as needed in `transformRow`.
+    transformRow: async (executionContext, actualQuery, row) => {
+      const { log, resultParser } = executionContext;
+
+      if (!resultParser) {
+        return row;
+      }
+
+      // It is recommended (but not required) to parse async to avoid blocking the event loop during validation
+      const validationResult = await resultParser.safeParseAsync(row);
+
+      if (!validationResult.success) {
+        throw new SchemaValidationError(
+          actualQuery,
+          row,
+          validationResult.error.issues
+        );
+      }
+
+      return validationResult.data as QueryResultRow;
+    },
+  };
+};
+```
+
+To use it, simply add it as a middleware:
+
+```ts
+import { createPool } from "slonik";
+
+createPool("postgresql://", {
+  interceptors: [createResultParserInterceptor()],
+});
+```
 
 ### Example use of `sql.type`
 
@@ -148,64 +201,5 @@ t.deepEqual(result, {
     x: 1,
     y: 2,
   },
-});
-```
-
-### Result parser interceptor
-
-Slonik works without the interceptor, but it doesn't validate the query results. To validate results, you must implement an interceptor that parses the results.
-
-For context, when Zod parsing was first introduced to Slonik, it was enabled for all queries by default. However, I eventually realized that the baked-in implementation is not going to suit everyone's needs. For this reason, I decided to take out the built-in interceptor in favor of providing examples for common use cases. What follows is the original default implementation.
-
-```ts
-import {
-  type Interceptor,
-  type QueryResultRow,
-  SchemaValidationError,
-} from 'slonik';
-
-const createResultParserInterceptor = (): Interceptor => {
-  return {
-    // If you are not going to transform results using Zod, then you should use `afterQueryExecution` instead.
-    // Future versions of Zod will provide a more efficient parser when parsing without transformations.
-    // You can even combine the two – use `afterQueryExecution` to validate results, and (conditionally)
-    // transform results as needed in `transformRow`.
-    transformRow: (executionContext, actualQuery, row) => {
-      const {
-        log,
-        resultParser,
-      } = executionContext;
-
-      if (!resultParser) {
-        return row;
-      }
-
-      const validationResult = resultParser.safeParse(row);
-
-      if (!validationResult.success) {
-        throw new SchemaValidationError(
-          actualQuery,
-          row,
-          validationResult.error.issues,
-        );
-      }
-
-      return validationResult.data as QueryResultRow;
-    },
-  };
-};
-```
-
-To use it, simply add it as a middleware:
-
-```ts
-import {
-  createPool,
-} from 'slonik';
-
-createPool('postgresql://', {
-  interceptors: [
-    createResultParserInterceptor(),
-  ]
 });
 ```

--- a/src/connectionMethods/stream.ts
+++ b/src/connectionMethods/stream.ts
@@ -47,7 +47,7 @@ const createTransformStream = (
 
   return new Transform({
     objectMode: true,
-    transform(datum, enc, callback) {
+    async transform(datum, enc, callback) {
       if (!fields) {
         callback(new Error('Fields not available'));
 
@@ -56,10 +56,9 @@ const createTransformStream = (
 
       let finalRow = datum;
 
-      if (rowTransformers.length) {
-        for (const rowTransformer of rowTransformers) {
-          finalRow = rowTransformer(queryContext, query, finalRow, fields);
-        }
+      // apply row transformers. Note this is done sequentially, as one transformer's result will be passed to the next.
+      for (const rowTransformer of rowTransformers) {
+        finalRow = await rowTransformer(queryContext, query, finalRow, fields);
       }
 
       // eslint-disable-next-line @babel/no-invalid-this

--- a/src/routines/executeQuery.ts
+++ b/src/routines/executeQuery.ts
@@ -375,11 +375,11 @@ export const executeQuery = async (
         const { transformRow } = interceptor;
         const { fields } = result;
 
-        const rows: QueryResultRow[] = [];
-
-        for (const row of result.rows) {
-          rows.push(transformRow(executionContext, actualQuery, row, fields));
-        }
+        const rows: QueryResultRow[] = await Promise.all(
+          result.rows.map(
+            row => transformRow(executionContext, actualQuery, row, fields)
+          )
+        );
 
         result = {
           ...result,

--- a/src/types.ts
+++ b/src/types.ts
@@ -554,7 +554,7 @@ export type Interceptor = {
     query: Query,
     row: QueryResultRow,
     fields: readonly Field[],
-  ) => QueryResultRow;
+  ) => MaybePromise<QueryResultRow>;
 };
 
 export type IdentifierNormalizer = (identifierName: string) => string;

--- a/test/slonik/connectionMethods/query/interceptors/transformRow.ts
+++ b/test/slonik/connectionMethods/query/interceptors/transformRow.ts
@@ -4,7 +4,7 @@ import test from 'ava';
 
 const sql = createSqlTag();
 
-test('overrides result row', async (t) => {
+test('overrides result row (sync)', async (t) => {
   const pool = await createPool({
     interceptors: [
       {
@@ -12,6 +12,47 @@ test('overrides result row', async (t) => {
           return {
             foo: 2,
           };
+        },
+      },
+    ],
+  });
+
+  pool.querySpy.returns({
+    command: 'SELECT',
+    fields: [],
+    rowCount: 1,
+    rows: [
+      {
+        foo: 1,
+      },
+    ],
+    type: 'QueryResult',
+  });
+
+  const result = await pool.query(sql.unsafe`SELECT 1`);
+
+  t.deepEqual(result, {
+    command: 'SELECT',
+    fields: [],
+    notices: [],
+    rowCount: 1,
+    rows: [
+      {
+        foo: 2,
+      },
+    ],
+    type: 'QueryResult',
+  });
+});
+
+test('overrides result row (async)', async t => {
+  const pool = await createPool({
+    interceptors: [
+      {
+        transformRow: () => {
+          return Promise.resolve({
+            foo: 2,
+          });
         },
       },
     ],


### PR DESCRIPTION
This implements the changes outlined in #539.

I also took the liberty of pulling up the "Result parser interceptor" section to the beginning of the runtime_validation section.
This felt reasonable, since this is the initial setup without which none of the following info would work.

I realise this makes reviewing the changes a bit more difficult, so here they are:
- [line 24](https://github.com/gajus/slonik/pull/540/files#diff-0f9cfa6ab7e48e7434ebbb29e5561db27af0193ce3830c703eb05360b6e826beR24): added "based on" as it's not exactly the original implementation anymore.
- [line 39](https://github.com/gajus/slonik/pull/540/files#diff-0f9cfa6ab7e48e7434ebbb29e5561db27af0193ce3830c703eb05360b6e826beR39): added 'async'
- [line 46](https://github.com/gajus/slonik/pull/540/files#diff-0f9cfa6ab7e48e7434ebbb29e5561db27af0193ce3830c703eb05360b6e826beR46): added comment
- [line 47](https://github.com/gajus/slonik/pull/540/files#diff-0f9cfa6ab7e48e7434ebbb29e5561db27af0193ce3830c703eb05360b6e826beR47): changed sync to async implementation

When looking more closely at the readme, I also noticed that the "Unknown keys" section seems to be outdated.
Zod does not fail on unknown keys by default, it just strips them.
I suspect this section is a relict from the brief time when zod was hard-wired into slonik.

I will create a [separate PR](https://github.com/gajus/slonik/pull/541) for this.