### PR TITLE
Fix docs about unknown keys

### DIFF
--- a/.README/RUNTIME_VALIDATION.md
+++ b/.README/RUNTIME_VALIDATION.md
@@ -72,7 +72,21 @@ Just to give an idea, in our sample of data, it takes sub 0.1ms to validate 1 ro
 
 ### Unknown keys
 
-Slonik disallows unknown keys, i.e. query that returns `{foo: 'bar', baz: 'qux'}` with `z.object({foo: z.string()})` schema will produce `SchemaValidationError` error.
+By default Zod object schemas strip unknown keys. If you want to disallow unknown keys, you can add [`.strict()`](https://zod.dev/?id=strict) to your schema:  
+
+```ts
+z.object({ foo: z.string() }).strict()
+```
+
+Using the [recommended parser pattern](#result-parser-interceptor), this will produce a `SchemaValidationError`, when a query result includes unknown keys.
+
+Conversely you can allow unknown keys to be passed through by using [`.passthrough()`](https://zod.dev/?id=passthrough):
+
+```ts
+z.object({ foo: z.string() }).passthrough();
+```
+
+_Note_: Using `.passthrough()` is not recommended as it reduces type safety and may lead to unexpected behaviour.
 
 ### Handling schema validation errors
 

--- a/README.md
+++ b/README.md
@@ -1324,7 +1324,21 @@ Just to give an idea, in our sample of data, it takes sub 0.1ms to validate 1 ro
 <a name="slonik-runtime-validation-unknown-keys"></a>
 ### Unknown keys
 
-Slonik disallows unknown keys, i.e. query that returns `{foo: 'bar', baz: 'qux'}` with `z.object({foo: z.string()})` schema will produce `SchemaValidationError` error.
+By default Zod object schemas strip unknown keys. If you want to disallow unknown keys, you can add [`.strict()`](https://zod.dev/?id=strict) to your schema:  
+
+```ts
+z.object({ foo: z.string() }).strict()
+```
+
+Using the [recommended parser pattern](#user-content-result-parser-interceptor), this will produce a `SchemaValidationError`, when a query result includes unknown keys.
+
+Conversely you can allow unknown keys to be passed through by using [`.passthrough()`](https://zod.dev/?id=passthrough):
+
+```ts
+z.object({ foo: z.string() }).passthrough();
+```
+
+_Note_: Using `.passthrough()` is not recommended as it reduces type safety and may lead to unexpected behaviour.
 
 <a name="user-content-slonik-runtime-validation-handling-schema-validation-errors"></a>
 <a name="slonik-runtime-validation-handling-schema-validation-errors"></a>


### PR DESCRIPTION
The current docs state that slonik will throw for unknown keys.
However, Zod does not throw for unknown keys by default, you'd have to tell it to.

The current docs are likely a relict of previous behaviour.