### PR TITLE
Update history of slonik link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Slonik has been [battle-tested](https://medium.com/@gajus/lessons-learned-scalin
 
 The name of the elephant depicted in the official PostgreSQL logo is Slonik. The name itself is derived from the Russian word for "little elephant".
 
-Read: [The History of Slonik, the PostgreSQL Elephant Logo](https://www.vertabelo.com/blog/notes-from-the-lab/the-history-of-slonik-the-postgresql-elephant-logo)
+Read: [The History of Slonik, the PostgreSQL Elephant Logo](https://learnsql.com/blog/the-history-of-slonik-the-postgresql-elephant-logo/)
 
 ### Repeating code patterns and type safety
 


### PR DESCRIPTION
The current link for "The History of Slonik, the PostgreSQL Elephant Logo" in the README leads to a 404 page on Vertabelo's website, and I wasn't able to find the article in their blog. This switches it to a working link on LearnSQL which I think probably has the same content since it has the same title