### PR TITLE
Protect against unsafe sql.fragment usage

### DIFF
--- a/packages/sql-tag/src/factories/createSqlTag.test/sql.test.ts
+++ b/packages/sql-tag/src/factories/createSqlTag.test/sql.test.ts
@@ -1,5 +1,6 @@
 import { FragmentToken } from '../../tokens';
 import { createSqlTag } from '../createSqlTag';
+import { InvalidInputError } from '@slonik/errors';
 import anyTest, { type TestFn } from 'ava';
 import { ROARR } from 'roarr';
 
@@ -15,6 +16,15 @@ test.beforeEach((t) => {
   ROARR.write = (message) => {
     t.context.logs.push(JSON.parse(message));
   };
+});
+
+test('throws error if called as a function', (t) => {
+  const error = t.throws(() => {
+    // @ts-expect-error - intentional
+    sql.fragment([`SELECT 1`]);
+  });
+
+  t.true(error instanceof InvalidInputError);
 });
 
 test('creates an object describing a query', (t) => {

--- a/packages/sql-tag/src/factories/createSqlTag.ts
+++ b/packages/sql-tag/src/factories/createSqlTag.ts
@@ -32,9 +32,15 @@ const log = Logger.child({
 });
 
 const createFragment = (
-  parts: readonly string[],
+  parts: TemplateStringsArray,
   values: readonly ValueExpression[],
 ) => {
+  if (!Array.isArray(parts.raw) || !Object.isFrozen(parts.raw)) {
+    throw new InvalidInputError(
+      'Function must be called as a template literal.',
+    );
+  }
+
   let rawSql = '';
 
   const parameterValues: PrimitiveValueExpression[] = [];
@@ -181,7 +187,7 @@ export const createSqlTag = <
     },
     type: (parser) => {
       return (
-        parts: readonly string[],
+        parts: TemplateStringsArray,
         ...args: readonly ValueExpression[]
       ) => {
         return Object.freeze({
@@ -199,7 +205,7 @@ export const createSqlTag = <
       }
 
       return (
-        parts: readonly string[],
+        parts: TemplateStringsArray,
         ...args: readonly ValueExpression[]
       ) => {
         return Object.freeze({


### PR DESCRIPTION
* in typescript: protects using types
* in javascript: protects by checking for strings.raw

Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#raw_strings

Closes #589