### PR TITLE
fix: close all connections in pool.end()

### DIFF
--- a/.changeset/giant-chicken-help.md
+++ b/.changeset/giant-chicken-help.md
@@ -1,0 +1,5 @@
+---
+"slonik": major
+---
+
+fix: close all connections in pool.end(). Previously a subset idleConnections would hang until idleTimeout was reached

--- a/packages/slonik/src/factories/createConnectionPool.ts
+++ b/packages/slonik/src/factories/createConnectionPool.ts
@@ -108,7 +108,11 @@ export const createConnectionPool = ({
     // e.g. "waits for all connections to be established before attempting to terminate the pool" test
     await delay(0);
 
-    await Promise.all(connections.map((connection) => connection.destroy()));
+    // Make a copy of `connections` array as items are removed from it during the map iteration.
+    // If `connections` array is used directly, the loop will skip some items.
+    await Promise.all(
+      [...connections].map((connection) => connection.destroy()),
+    );
   };
 
   const acquire = async () => {

--- a/packages/slonik/src/helpers.test/createIntegrationTests.ts
+++ b/packages/slonik/src/helpers.test/createIntegrationTests.ts
@@ -926,7 +926,7 @@ export const createIntegrationTests = (
 
     const pool = await createPool(t.context.dsn, {
       driverFactory,
-      idleTimeout: 500,
+      idleTimeout: 'DISABLE_TIMEOUT',
       maximumPoolSize: 5,
     });
 
@@ -967,8 +967,6 @@ export const createIntegrationTests = (
     });
 
     await pool.end();
-
-    await delay(600);
 
     t.deepEqual(pool.state(), {
       acquiredConnections: 0,


### PR DESCRIPTION
There is an issue with `pool.end()`. If you have multiple idle connections and then call `pool.end()` it will actually only close a subset of the idle connections. The reason is that as part of `onDestory` there is a splice operation on the global `connections` array. As `pool.end()` is mapping over `connections` we're removing items from the array so it misses some.

So what actually happens today:
1. Open 5 connections
1. Call `await pool.end()`
2. Only 3 of the connections are closed, `pool.end()` resolves
3. Once `idleTimeout` expires for the remaining 2 connections, those 2 will be closed as well
   - This is where it gets problematic. If you have a high `idleTimeout` setting, there will be hanging connections until `idleTimeout` is hit, even after `pool.end()` resolves

Simple reproduction:
```javascript
const { createPool, sql } = require('slonik');

async function main() {
  const pool = await createPool('postgres://postgres:postgres@localhost:5432/mike', {
    maximumPoolSize: 5,
    idleTimeout: 10000,
  });

  let i = 1;
  async function executeQuery() {
    try {
      console.log('Running query ', i++);
      await pool.query(sql.unsafe`SELECT 1`);
    } catch (err) {
      console.error('Query failed:', err);
    }
  }

  const queryPromises = Array(5).fill().map(() => executeQuery());
  await Promise.all(queryPromises);

  console.log('\nPool state', pool.state());

  // Close the pool
  console.log('\nClosing pool...')
  await pool.end();
  console.log('Pool closed');

  console.log('\nPool state', pool.state());
}

main().catch(err => console.error('Error in main:', err));

```

This will ouptut:
```bash
Running query  1
Running query  2
Running query  3
Running query  4
Running query  5

Pool state {
  acquiredConnections: 0,
  idleConnections: 5,
  pendingDestroyConnections: 0,
  pendingReleaseConnections: 0,
  state: 'ACTIVE',
  waitingClients: 0
}

Closing pool...
Pool closed

# 👀 Note how there are still 2 idle connections even after the pool says its 'ENDED'
Pool state {
  acquiredConnections: 0,
  idleConnections: 2,
  pendingDestroyConnections: 0,
  pendingReleaseConnections: 0,
  state: 'ENDED',
  waitingClients: 0
}

# ⏳ The process now hangs for 10s (idleTimeout setting)
```
