### PR TITLE
Align sslMode with current libpq-connect options

### DIFF
--- a/.changeset/hot-shoes-destroy.md
+++ b/.changeset/hot-shoes-destroy.md
@@ -1,0 +1,6 @@
+---
+"@slonik/types": major
+---
+
+Aligned `sslMode` type with [current](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE) libpq-connect options
+**Potentially breaking (types)**: removed `'no-verify'` option

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -36,7 +36,7 @@ export type ConnectionOptions = {
   options?: string;
   password?: string;
   port?: number;
-  sslMode?: 'disable' | 'no-verify' | 'require';
+  sslMode?: 'disable' | 'allow' | 'prefer' | 'require' | 'verify-ca' | 'verify-full' ;
   username?: string;
 };
 


### PR DESCRIPTION
This PR aligns TypeScript types with [current](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE) `libpq-connect` options