### PR TITLE
perf: avoid O(n²) record matching in createNodeByIdLoaderClass

### DIFF
--- a/.changeset/fix-node-loader-quadratic-lookup.md
+++ b/.changeset/fix-node-loader-quadratic-lookup.md
@@ -1,0 +1,16 @@
+---
+"@slonik/dataloaders": patch
+---
+
+Fix O(n²) record matching in `createNodeByIdLoaderClass`
+
+The node-by-id DataLoader batches all keys into a single query, but then
+matched the returned rows back to the requested keys using
+`Array.prototype.find` inside a `map`, making the in-memory join O(n²) in the
+batch size. For large batches this added significant synchronous, event-loop
+blocking CPU time after the query had already returned (e.g. ~800ms for a
+10,000-key batch).
+
+The rows are now indexed into a `Map` once and looked up in O(1) per key —
+mirroring the grouping approach already used in `batchQueries`. Behaviour is
+unchanged, including first-match-wins semantics for duplicate key values.

--- a/packages/slonik-dataloaders/src/factories/createNodeByIdLoaderClass.ts
+++ b/packages/slonik-dataloaders/src/factories/createNodeByIdLoaderClass.ts
@@ -50,10 +50,18 @@ export const createNodeByIdLoaderClass = <T extends ZodType>(config: {
             `,
           );
 
+          const recordsByKey = new Map<string, (typeof records)[number]>();
+
+          for (const record of records) {
+            const key = String(record[columnName as keyof typeof record]);
+
+            if (!recordsByKey.has(key)) {
+              recordsByKey.set(key, record);
+            }
+          }
+
           return loaderKeys.map((value) => {
-            const targetRecord = records.find((record) => {
-              return String(record[columnName as keyof typeof record]) === String(value);
-            });
+            const targetRecord = recordsByKey.get(String(value));
 
             if (targetRecord) {
               return targetRecord as z.infer<T>;


### PR DESCRIPTION
## Summary

`createNodeByIdLoaderClass` batches all requested keys into a single `= ANY(...)` query (good — one round-trip), but then matches the returned rows back to the requested keys using `Array.prototype.find` inside a `map`:

```ts
return loaderKeys.map((value) => {
  const targetRecord = records.find((record) => {
    return String(record[columnName]) === String(value);
  });
  ...
});
```

This makes the in-memory join **O(n²)** in the batch size. Since a node loader typically returns ~one row per key, an `n`-key batch does up to `n × n` string comparisons. It's synchronous, event-loop-blocking CPU spent *after* the query has already returned — so it doesn't show up as slow SQL, just as a stalled event loop under load.

## Evidence

Isolating only the matching step (no DB), the current code scales quadratically, while a `Map`-based lookup stays linear and is equivalent in output:

| batch size | current (`.find`) | fixed (`Map`) | speedup |
|-----------:|------------------:|--------------:|--------:|
|        100 |          0.07 ms  |     0.005 ms  |    13×  |
|       1000 |          7.2 ms   |     0.06 ms   |   122×  |
|       5000 |          217 ms   |     0.38 ms   |   569×  |
|      10000 |          799 ms   |     1.06 ms   |   753×  |

Doubling the batch ~4× the time confirms the O(n²) curve; the fix grows linearly.

## Fix

Index the returned rows into a `Map` keyed by the lookup column once (O(n)), then do an O(1) lookup per key:

```ts
const recordsByKey = new Map<string, (typeof records)[number]>();

for (const record of records) {
  const key = String(record[columnName]);

  if (!recordsByKey.has(key)) {
    recordsByKey.set(key, record);
  }
}

return loaderKeys.map((value) => {
  const targetRecord = recordsByKey.get(String(value));
  ...
});
```

This mirrors the `Map`-based grouping already used in `batchQueries`.